### PR TITLE
Fixes reporting the wrong version missing in a file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.0.270'
+    rev: 'v0.0.272'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/bumpversion/files.py
+++ b/bumpversion/files.py
@@ -209,4 +209,5 @@ def _check_files_contain_version(
         ", ".join({str(f.path) for f in files}),
     )
     for f in files:
+        context["current_version"] = f.version_config.serialize(current_version, context)
         f.contains_version(current_version, context)

--- a/bumpversion/version_part.py
+++ b/bumpversion/version_part.py
@@ -228,7 +228,7 @@ class VersionConfig:
         except KeyError as e:
             missing_key = getattr(e, "message", e.args[0])
             raise MissingValueError(
-                f"Did not find key {missing_key!r} in {repr(version)} when serializing version number"
+                f"Did not find key {missing_key!r} in {version!r} when serializing version number"
             ) from e
 
         keys_needing_representation = set()


### PR DESCRIPTION
- Fixes issue #20
- Renders the correct `current_version` for each file being modified.