### PR TITLE
Feature/fix wrong evaluation order in tag in scm

### DIFF
--- a/bumpversion/scm.py
+++ b/bumpversion/scm.py
@@ -161,16 +161,16 @@ class SourceCodeManager:
     @classmethod
     def tag_in_scm(cls, config: "Config", context: MutableMapping, dry_run: bool = False) -> None:
         """Tag the current commit in the source code management system."""
-        sign_tags = config.sign_tags
-        tag_name = config.tag_name.format(**context)
-        tag_message = config.tag_message.format(**context)
-        existing_tags = cls.get_all_tags()
         if not config.commit:
             logger.info("Would not tag since we are not committing")
             return
         if not config.tag:
             logger.info("Would not tag")
             return
+        sign_tags = config.sign_tags
+        tag_name = config.tag_name.format(**context)
+        tag_message = config.tag_message.format(**context)
+        existing_tags = cls.get_all_tags()
 
         do_tag = not dry_run
 


### PR DESCRIPTION
Maybe I am doing something wrong but I got a key error when trying to bump without tagging and commiting.. Seems that tag_in_scm is not checking the config immediately when entering, rather tries to fetch tag details from the config (which in my config file does not exist because I explicitly do tag = false. 
So I moved the config checks in the beginning just like it's done for commit_to_scm.