### PR TITLE
Fix search and replace options for replace.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.0.276'
+    rev: 'v0.0.277'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
         exclude: test.*
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -408,8 +408,6 @@ def replace(
         new_version=new_version,
         parse=parse,
         serialize=serialize or None,
-        search=search,
-        replace=replace,
         commit=False,
         tag=False,
         sign_tags=False,
@@ -441,6 +439,6 @@ def replace(
 
     ctx = get_context(config, version, next_version)
 
-    configured_files = resolve_file_config(config.files, config.version_config)
+    configured_files = resolve_file_config(config.files, config.version_config, search, replace)
 
     modify_files(configured_files, version, next_version, ctx, dry_run)

--- a/bumpversion/files.py
+++ b/bumpversion/files.py
@@ -103,8 +103,7 @@ class ConfiguredFile:
             file_content_before = f.read()
             file_new_lines = f.newlines[0] if isinstance(f.newlines, tuple) else f.newlines
 
-        if current_version:
-            context["current_version"] = self.version_config.serialize(current_version, context)
+        context["current_version"] = self.version_config.serialize(current_version, context)
         if new_version:
             context["new_version"] = self.version_config.serialize(new_version, context)
 
@@ -135,14 +134,14 @@ class ConfiguredFile:
         else:
             logger.info("%s file %s", "Would not change" if dry_run else "Not changing", self.path)
 
-        if not dry_run:
+        if not dry_run:  # pragma: no-coverage
             with open(self.path, "wt", encoding="utf-8", newline=file_new_lines) as f:
                 f.write(file_content_after)
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: no-coverage
         return self.path
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no-coverage
         return f"<bumpversion.ConfiguredFile:{self.path}>"
 
 

--- a/bumpversion/files.py
+++ b/bumpversion/files.py
@@ -2,7 +2,7 @@
 import glob
 import logging
 from difflib import context_diff
-from typing import List, MutableMapping
+from typing import List, MutableMapping, Optional
 
 from bumpversion.config import FileConfig
 from bumpversion.exceptions import VersionNotFoundError
@@ -14,12 +14,18 @@ logger = logging.getLogger(__name__)
 class ConfiguredFile:
     """A file to modify in a configured way."""
 
-    def __init__(self, file_cfg: FileConfig, version_config: VersionConfig) -> None:
+    def __init__(
+        self,
+        file_cfg: FileConfig,
+        version_config: VersionConfig,
+        search: Optional[str] = None,
+        replace: Optional[str] = None,
+    ) -> None:
         self.path = file_cfg.filename
         self.parse = file_cfg.parse or version_config.parse_regex.pattern
         self.serialize = file_cfg.serialize or version_config.serialize_formats
-        self.search = file_cfg.search or version_config.search
-        self.replace = file_cfg.replace or version_config.replace
+        self.search = search or file_cfg.search or version_config.search
+        self.replace = replace or file_cfg.replace or version_config.replace
         self.version_config = VersionConfig(
             self.parse, self.serialize, self.search, self.replace, version_config.part_configs
         )
@@ -97,8 +103,10 @@ class ConfiguredFile:
             file_content_before = f.read()
             file_new_lines = f.newlines[0] if isinstance(f.newlines, tuple) else f.newlines
 
-        context["current_version"] = self.version_config.serialize(current_version, context)
-        context["new_version"] = self.version_config.serialize(new_version, context)
+        if current_version:
+            context["current_version"] = self.version_config.serialize(current_version, context)
+        if new_version:
+            context["new_version"] = self.version_config.serialize(new_version, context)
 
         search_for = self.version_config.search.format(**context)
         replace_with = self.version_config.replace.format(**context)
@@ -138,13 +146,17 @@ class ConfiguredFile:
         return f"<bumpversion.ConfiguredFile:{self.path}>"
 
 
-def resolve_file_config(files: List[FileConfig], version_config: VersionConfig) -> List[ConfiguredFile]:
+def resolve_file_config(
+    files: List[FileConfig], version_config: VersionConfig, search: Optional[str] = None, replace: Optional[str] = None
+) -> List[ConfiguredFile]:
     """
     Resolve the files, searching and replacing values according to the FileConfig.
 
     Args:
         files: A list of file configurations
         version_config: How the version should be changed
+        search: The search pattern to use instead of any configured search pattern
+        replace: The replace pattern to use instead of any configured replace pattern
 
     Returns:
         A list of ConfiguredFiles
@@ -154,7 +166,7 @@ def resolve_file_config(files: List[FileConfig], version_config: VersionConfig) 
         if file_cfg.glob:
             configured_files.extend(get_glob_files(file_cfg, version_config))
         else:
-            configured_files.append(ConfiguredFile(file_cfg, version_config))
+            configured_files.append(ConfiguredFile(file_cfg, version_config, search, replace))
 
     return configured_files
 
@@ -181,13 +193,17 @@ def modify_files(
         f.replace_version(current_version, new_version, context, dry_run)
 
 
-def get_glob_files(file_cfg: FileConfig, version_config: VersionConfig) -> List[ConfiguredFile]:
+def get_glob_files(
+    file_cfg: FileConfig, version_config: VersionConfig, search: Optional[str] = None, replace: Optional[str] = None
+) -> List[ConfiguredFile]:
     """
     Return a list of files that match the glob pattern.
 
     Args:
         file_cfg: The file configuration containing the glob pattern
         version_config: The version configuration
+        search: The search pattern to use instead of any configured search pattern
+        replace: The replace pattern to use instead of any configured replace pattern
 
     Returns:
         A list of resolved files according to the pattern.
@@ -196,7 +212,7 @@ def get_glob_files(file_cfg: FileConfig, version_config: VersionConfig) -> List[
     for filename_glob in glob.glob(file_cfg.glob, recursive=True):
         new_file_cfg = file_cfg.copy()
         new_file_cfg.filename = filename_glob
-        files.append(ConfiguredFile(new_file_cfg, version_config))
+        files.append(ConfiguredFile(new_file_cfg, version_config, search, replace))
     return files
 
 


### PR DESCRIPTION
- The `--search` and `--replace` options now completely override any other search and replace logic.

Fixes #34