### PR TITLE
Drop Python3.7 as compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Software Distribution",
 ]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 keywords = ["bumpversion", "version", "release"]
 dynamic = ["version"]


### PR DESCRIPTION
Since this is no longer tested, it's safer to start at 3.8.

3.7 was dropped in #53.