### PR TITLE
Recommend calling 'bump-my-version' instead of 'bumpversion'

### DIFF
--- a/bumpversion/aliases.py
+++ b/bumpversion/aliases.py
@@ -40,7 +40,8 @@ class AliasedGroup(RichGroup):
                 original_args.remove("bump")
             else:
                 print_warning(
-                    "Calling bumpversion without a subcommand is deprecated. " "Please use `bump-my-version bump` instead"
+                    "Calling bumpversion without a subcommand is deprecated. "
+                    "Please use `bump-my-version bump` instead"
                 )
             return cmd.name, cmd, original_args
         return cmd.name, cmd, args

--- a/bumpversion/aliases.py
+++ b/bumpversion/aliases.py
@@ -40,7 +40,7 @@ class AliasedGroup(RichGroup):
                 original_args.remove("bump")
             else:
                 print_warning(
-                    "Calling bumpversion without a subcommand is deprecated. " "Please use `bumpversion bump` instead"
+                    "Calling bumpversion without a subcommand is deprecated. " "Please use `bump-my-version bump` instead"
                 )
             return cmd.name, cmd, original_args
         return cmd.name, cmd, args


### PR DESCRIPTION
This seems out of date, since the 'bumpversion' command is  not installed.