### PR TITLE
feat: add Docker image to run without installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git/
+.github/
+.pytest_cache/
+bump_my_version.egg-info/
+docsrc/
+tests/
+tools/
+.*
+*.md
+*.yaml
+CODEOWNERS
+Dockerfile
+LICENSE
+Makefile
+MANIFEST.in

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily" # Update Docker tags daily
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly" # Update GitHub Actions weekly
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily" # Update pip dependencies daily

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ FROM python:3.12.0-alpine
 COPY --from=0 /etc/passwd /etc/group /etc/
 COPY --from=0 --chown=1000:1000 /app/venv/ /app/venv/
 USER app
+WORKDIR /in
+WORKDIR /out
 
 LABEL org.opencontainers.image.authors="Calloway https://github.com/callowayproject"
 LABEL org.opencontainers.image.base.name="docker.io/library/python:3.12.0-alpine"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12.0-alpine
+
+WORKDIR /app
+COPY . .
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app \
+ && python -m venv venv \
+ && source venv/bin/activate \
+ && pip install --no-cache-dir .
+
+
+FROM python:3.12.0-alpine
+COPY --from=0 /etc/passwd /etc/group /etc/
+COPY --from=0 --chown=1000:1000 /app/venv/ /app/venv/
+USER app
+
+LABEL org.opencontainers.image.authors="Calloway https://github.com/callowayproject"
+LABEL org.opencontainers.image.base.name="docker.io/library/python:3.12.0-alpine"
+LABEL org.opencontainers.image.description="A small command line tool to simplify releasing software by updating all version strings in your source code by the correct increment and optionally commit and tag the changes."
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/callowayproject/bump-my-version"
+LABEL org.opencontainers.image.title="bump-my-version"
+LABEL org.opencontainers.image.version="0.11.0"
+
+ENTRYPOINT ["/app/venv/bin/bump-my-version"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ You can download and install the latest version of this software from the Python
 pip install --upgrade bump-my-version
 ```
 
+## Docker
+
+Just bump a version number inside a CI workflow: 
+```console
+NEW_VERSION=$(docker run --rm calloway/bump-my-version patch $CURRENT_VERSION)
+```
+
+Run in the current working directory:
+```console
+docker run --rm -v "$PWD":/out calloway/bump-my-version bump --current-version 0.5.1 minor
+```
+
+Access config file outside the current working directory:
+```console
+docker run --rm -v /tmp:/in -v "$PWD":/out calloway/bump-my-version bump --config-file /in/bumpversion.toml --current-version 0.5.1 minor
+```
+
 ## Changelog
 
 Please find the changelog here: [CHANGELOG.md](CHANGELOG.md)

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -350,6 +350,30 @@ def show(args: List[str], config_file: Optional[str], format_: str, increment: O
 
 
 @cli.command()
+@click.argument("current_version", nargs=1, type=str)
+def major(current_version: List[str]) -> None:
+    """Bump current_version to next major version without changing files."""
+    conf = get_configuration(current_version=current_version)
+    do_show("new_version", config=conf, format_="default", increment="major")
+
+
+@cli.command()
+@click.argument("current_version", nargs=1, type=str)
+def minor(current_version: List[str]) -> None:
+    """Bump current_version to next minor version without changing files."""
+    conf = get_configuration(current_version=current_version)
+    do_show("new_version", config=conf, format_="default", increment="minor")
+
+
+@cli.command()
+@click.argument("current_version", nargs=1, type=str)
+def patch(current_version: List[str]) -> None:
+    """Bump current_version to next patch version without changing files."""
+    conf = get_configuration(current_version=current_version)
+    do_show("new_version", config=conf, format_="default", increment="patch")
+
+
+@cli.command()
 @click.argument("files", nargs=-1, type=str)
 @click.option(
     "--config-file",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,54 @@ def test_show(tmp_path: Path, fixtures_path: Path):
     assert result.output.splitlines(keepends=False) == ["1.0.0"]
 
 
+def test_major(tmp_path: Path):
+    """The major subcommand should bump the given value to the next major version."""
+    # Arrange
+    runner: CliRunner = CliRunner()
+
+    with inside_dir(tmp_path):
+        result: Result = runner.invoke(cli.cli, ["major", "v0.1.2"])
+
+    if result.exit_code != 0:
+        print(result.output)
+        print(result.exception)
+
+    assert result.exit_code == 0
+    assert result.output.splitlines(keepends=False) == ["1.0.0"]
+
+
+def test_minor(tmp_path: Path):
+    """The minor subcommand should bump the given value to the next minor version."""
+    # Arrange
+    runner: CliRunner = CliRunner()
+
+    with inside_dir(tmp_path):
+        result: Result = runner.invoke(cli.cli, ["minor", "v0.0.2"])
+
+    if result.exit_code != 0:
+        print(result.output)
+        print(result.exception)
+
+    assert result.exit_code == 0
+    assert result.output.splitlines(keepends=False) == ["0.1.0"]
+
+
+def test_patch(tmp_path: Path):
+    """The patch subcommand should bump the given value to the next patch version."""
+    # Arrange
+    runner: CliRunner = CliRunner()
+
+    with inside_dir(tmp_path):
+        result: Result = runner.invoke(cli.cli, ["patch", "v1.2.3"])
+
+    if result.exit_code != 0:
+        print(result.output)
+        print(result.exception)
+
+    assert result.exit_code == 0
+    assert result.output.splitlines(keepends=False) == ["1.2.4"]
+
+
 def test_show_and_increment(tmp_path: Path, fixtures_path: Path):
     """The show subcommand should incrment the version and display it."""
     # Arrange


### PR DESCRIPTION
* add Docker image to run without installation
* add shortcuts for docker run (stdout only)
* let Dependabot update docker, pip, GitHub Actions

In order to allow more integration scenarios we allow bumping to stdout only without changing files.

```shell
CURRENT_VERSION=1.2.3
NEW_VERSION=$(docker run --rm bump-my-version patch $CURRENT_VERSION)
```