### PR TITLE
Fix miscast of current_version

### DIFF
--- a/bumpversion/config/files_legacy.py
+++ b/bumpversion/config/files_legacy.py
@@ -43,6 +43,8 @@ def read_ini_file(file_path: Path) -> Dict[str, Any]:  # noqa: C901
         section_parts = section_name.split(":")
         num_parts = len(section_parts)
         options = {key: autocast.autocast_value(val) for key, val in config_parser.items(section_name)}
+        if "current_version" in options:
+            options["current_version"] = str(options["current_version"])
 
         if num_parts == 1:  # bumpversion section
             bumpversion_options.update(options)

--- a/tests/test_config/test_files_legacy.py
+++ b/tests/test_config/test_files_legacy.py
@@ -148,3 +148,22 @@ def test_utf8_message_from_config_file(tmp_path: Path, cfg_file):
         cfg = config.get_configuration(cfg_path)
 
     assert cfg.message == "Nová verze: {current_version} ☃, {new_version} ☀"
+
+
+def test_current_version_is_always_a_string(tmp_path: Path):
+    cfg_path = tmp_path / ".bumpversion.cfg"
+    initial_config = (
+        "[bumpversion]\n"
+        "current_version = 2\n"
+        "commit = False\n"
+        "tag = False\n"
+        "parse = (?P<major>\d+)\n"
+        "serialize = \n"
+        "	{major}\n"
+    )
+    cfg_path.write_bytes(initial_config.encode("utf-8"))
+
+    with inside_dir(tmp_path):
+        cfg = config.get_configuration(cfg_path)
+
+    assert cfg.current_version == "2"


### PR DESCRIPTION
- When using the legacy configuration format, a single-digit version is parsed as an int

Fixes #99