### PR TITLE
Fix not being able to tag without also committing

### DIFF
--- a/bumpversion/scm.py
+++ b/bumpversion/scm.py
@@ -177,9 +177,6 @@ class SourceCodeManager:
     @classmethod
     def tag_in_scm(cls, config: "Config", context: MutableMapping, dry_run: bool = False) -> None:
         """Tag the current commit in the source code management system."""
-        if not config.commit:
-            logger.info("Would not tag since we are not committing")
-            return
         if not config.tag:
             logger.info("Would not tag")
             return

--- a/tests/test_scm.py
+++ b/tests/test_scm.py
@@ -160,7 +160,7 @@ def test_commit_and_tag_from_below_scm_root(repo: str, scm_command: str, scm_cla
     [
         param(True, True, True, False, False, id="dry-run-stops-commit-and-tag"),
         param(True, False, False, True, False, id="commit-no-tag"),
-        param(False, True, False, False, False, id="no-commit-stops-tag"),
+        param(False, True, False, False, True, id="no-commit-will-tag"),
     ],
 )
 def test_commit_tag_dry_run_interactions(


### PR DESCRIPTION
Fixes #113

Please note: I have no experience with mercurial, and as such I do not know if mercurial would allow tagging without committing.

Tests are also updated and are all green.