### PR TITLE
Add support for legacy multiline search options (refs #98)

### DIFF
--- a/bumpversion/config/files_legacy.py
+++ b/bumpversion/config/files_legacy.py
@@ -58,6 +58,8 @@ def read_ini_file(file_path: Path) -> Dict[str, Any]:  # noqa: C901
                 "filename": section_parts[2],
             }
             file_options.update(options)
+            if "search" in file_options and isinstance(file_options["search"], list):
+                file_options["search"] = "\n".join(file_options["search"])
             if "replace" in file_options and isinstance(file_options["replace"], list):
                 file_options["replace"] = "\n".join(file_options["replace"])
             bumpversion_options["files"].append(file_options)
@@ -66,6 +68,8 @@ def read_ini_file(file_path: Path) -> Dict[str, Any]:  # noqa: C901
                 "glob": section_parts[2],
             }
             file_options.update(options)
+            if "search" in file_options and isinstance(file_options["search"], list):
+                file_options["search"] = "\n".join(file_options["search"])
             if "replace" in file_options and isinstance(file_options["replace"], list):
                 file_options["replace"] = "\n".join(file_options["replace"])
             bumpversion_options["files"].append(file_options)

--- a/tests/fixtures/legacy_multiline_search.cfg
+++ b/tests/fixtures/legacy_multiline_search.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 1.0.0
+
+[bumpversion:file:MULTILINE_SEARCH.md]
+search = **unreleased**
+	**v{current_version}**
+replace = **unreleased**
+	**v{new_version}**

--- a/tests/fixtures/legacy_multiline_search_expected.json
+++ b/tests/fixtures/legacy_multiline_search_expected.json
@@ -1,0 +1,11 @@
+{
+  "current_version": "1.0.0",
+  "files": [
+    {
+      "filename": "MULTILINE_SEARCH.md",
+      "search": "**unreleased**\n**v{current_version}**",
+      "replace": "**unreleased**\n**v{new_version}**"
+    }
+  ],
+  "parts": {}
+}

--- a/tests/test_config/test_files_legacy.py
+++ b/tests/test_config/test_files_legacy.py
@@ -34,6 +34,7 @@ def cfg_file(request) -> str:
     ["conf_file", "expected_file"],
     [
         param("basic_cfg.cfg", "basic_cfg_expected.json", id="ini basic cfg"),
+        param("legacy_multiline_search.cfg", "legacy_multiline_search_expected.json", id="multiline search cfg"),
     ],
 )
 def test_read_ini_file(conf_file: str, expected_file: str, fixtures_path: Path) -> None:


### PR DESCRIPTION
Support multiline `search` options in legacy config files.