### PR TITLE
Fixed empty string replacement bug

### DIFF
--- a/bumpversion/files.py
+++ b/bumpversion/files.py
@@ -74,11 +74,13 @@ class ConfiguredFile:
         search: Optional[str] = None,
         replace: Optional[str] = None,
     ) -> None:
+        replacements = [replace, file_change.replace, version_config.replace]
+        replacement = next((r for r in replacements if r is not None), "")
         self.file_change = FileChange(
             parse=file_change.parse or version_config.parse_regex.pattern,
             serialize=file_change.serialize or version_config.serialize_formats,
             search=search or file_change.search or version_config.search,
-            replace=replace or file_change.replace or version_config.replace,
+            replace=replacement,
             regex=file_change.regex or False,
             ignore_missing_version=file_change.ignore_missing_version or False,
             filename=file_change.filename,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -576,6 +576,7 @@ def test_replace_with_empty_string(tmp_path, fixtures_path):
             cli.cli,
             [
                 "replace",
+                "--verbose",
                 "--no-configured-files",
                 "--allow-dirty",
                 "--search",
@@ -590,8 +591,8 @@ def test_replace_with_empty_string(tmp_path, fixtures_path):
         print("Here is the output:")
         print(result.output)
         print(traceback.print_exception(result.exc_info[1]))
-
     assert result.exit_code == 0
+    assert doc_path.read_text() == "We should censor \n\n"
 
 
 def test_valid_regex_not_ignoring_regex(tmp_path: Path, caplog) -> None:


### PR DESCRIPTION
Only a missing replacement value will trigger one of the fallback options.

Fixes #117