### PR TITLE
Force utf 8 encoding on writes

### DIFF
--- a/.github/workflows/docs-final.yml
+++ b/.github/workflows/docs-final.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+  pages: write
+
 jobs:
   build:
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -10,6 +10,11 @@ on:
 
 concurrency: preview-${{ github.ref }}
 
+permissions:
+  contents: read
+  pull-requests: write
+  pages: write
+
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -81,6 +81,7 @@ jobs:
               ;;
             dev)
               bump-my-version bump --allow-dirty --verbose --no-commit --no-tag "$RELEASE_KIND"
+              echo "PACKAGE=true" >> $GITHUB_ENV
               ;;
           esac
 

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -548,7 +548,7 @@ def sample_config(prompt: bool, destination: str) -> None:
     if destination == "stdout":
         print_info(dumps(destination_config))
     else:
-        Path(destination).write_text(dumps(destination_config))
+        Path(destination).write_text(dumps(destination_config), encoding="utf-8")
 
 
 @cli.command()

--- a/bumpversion/config/files_legacy.py
+++ b/bumpversion/config/files_legacy.py
@@ -132,4 +132,4 @@ def update_ini_config_file(
     )
 
     if not dry_run:
-        config_path.write_text(new_config)
+        config_path.write_text(new_config, encoding="utf-8")

--- a/bumpversion/files.py
+++ b/bumpversion/files.py
@@ -359,4 +359,4 @@ class DataFileUpdater:
 
         set_nested_value(toml_data, new_value, self.file_change.key_path)
 
-        self.path.write_text(tomlkit.dumps(toml_data))
+        self.path.write_text(tomlkit.dumps(toml_data), encoding="utf-8")

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -217,7 +217,8 @@ def test_key_path_required_for_toml_change(tmp_path: Path, caplog):
             bake_cookies = true
             ignore-words-list = "sugar, salt, flour"
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     conf = config.get_configuration(config_file=config_path)

--- a/tests/test_cli/test_bump.py
+++ b/tests/test_cli/test_bump.py
@@ -64,10 +64,10 @@ def test_bump_nested_regex(tmp_path: Path, fixtures_path: Path, caplog, runner):
     Assert: There is no configured files specified to modify
     """
     cff_path = tmp_path / "citation.cff"
-    cff_path.write_text("cff-version: 1.2.0\ndate-released: 2023-09-19\n")
+    cff_path.write_text("cff-version: 1.2.0\ndate-released: 2023-09-19\n", encoding="utf-8")
     content = fixtures_path.joinpath("regex_test_config.toml").read_text()
     config_path = tmp_path / ".bumpversion.toml"
-    config_path.write_text(content)
+    config_path.write_text(content, encoding="utf-8")
 
     with inside_dir(tmp_path):
         result: Result = runner.invoke(cli.cli, ["bump", "-vv", "patch"])
@@ -162,7 +162,7 @@ def test_dirty_work_dir_raises_error(repo: str, scm_command: str, request, runne
     repo_path: Path = request.getfixturevalue(repo)
     with inside_dir(repo_path):
         # Arrange
-        repo_path.joinpath("dirty2").write_text("i'm dirty! 1.1.1")
+        repo_path.joinpath("dirty2").write_text("i'm dirty! 1.1.1", encoding="utf-8")
         subprocess.run([scm_command, "add", "dirty2"], check=True)
 
         # Act
@@ -182,7 +182,7 @@ def test_non_scm_operations_if_scm_not_installed(tmp_path: Path, monkeypatch, ru
 
     with inside_dir(tmp_path):
         version_path = tmp_path / "VERSION"
-        version_path.write_text("31.0.3")
+        version_path.write_text("31.0.3", encoding="utf-8")
 
         # Act
         runner.invoke(cli.cli, ["bump", "major", "--current-version", "31.0.3", "VERSION"])
@@ -205,7 +205,7 @@ def test_detects_bad_or_missing_version_part(version_part: str, tmp_path: Path, 
 
     with inside_dir(tmp_path):
         version_path = tmp_path / "VERSION"
-        version_path.write_text("31.0.3")
+        version_path.write_text("31.0.3", encoding="utf-8")
 
         args = ["bump", "--current-version", "31.0.3"]
         if version_part:
@@ -229,7 +229,8 @@ def test_ignores_missing_files_with_option(tmp_path, fixtures_path, runner):
         "allow_dirty = true\n\n"
         "[[tool.bumpversion.files]]\n"
         'filename = "VERSION"\n'
-        "regex = false\n"
+        "regex = false\n",
+        encoding="utf-8",
     )
 
     # Act

--- a/tests/test_cli/test_replace.py
+++ b/tests/test_cli/test_replace.py
@@ -122,7 +122,8 @@ class TestReplaceCLI:
                 "allow_dirty = true\n\n"
                 "[[tool.bumpversion.files]]\n"
                 'filename = "VERSION"\n'
-                "regex = false\n"
+                "regex = false\n",
+                encoding="utf-8",
             )
 
             # Act
@@ -156,9 +157,11 @@ class TestReplaceCLI:
 
             # Arrange
             config_path = tmp_path / "pyproject.toml"
-            config_path.write_text(dumps(TEST_REPLACE_CONFIG))
+            config_path.write_text(dumps(TEST_REPLACE_CONFIG), encoding="utf-8")
             doc_path = tmp_path / "docs.yaml"
-            doc_path.write_text("url: https://github.com/sampleuser/workflows/main/.github/update_mailmap.py")
+            doc_path.write_text(
+                "url: https://github.com/sampleuser/workflows/main/.github/update_mailmap.py", encoding="utf-8"
+            )
 
             with inside_dir(tmp_path):
                 result: Result = runner.invoke(
@@ -189,7 +192,8 @@ class TestReplaceCLI:
 
             version_path = tmp_path / "VERSION"
             version_path.write_text(
-                "# Changelog\n\n## [0.0.1 (unreleased)](https://cool.url)\n\n- Test unreleased package.\n"
+                "# Changelog\n\n## [0.0.1 (unreleased)](https://cool.url)\n\n- Test unreleased package.\n",
+                encoding="utf-8",
             )
             config_file = tmp_path / ".bumpversion.toml"
             config_file.write_text(
@@ -200,7 +204,8 @@ class TestReplaceCLI:
                 'filename = "VERSION"\n'
                 "regex = false\n"
                 f'search = "{search}"\n'
-                f'replace = "{replace}"\n'
+                f'replace = "{replace}"\n',
+                encoding="utf-8",
             )
 
             # Act
@@ -241,9 +246,9 @@ class TestReplaceCLI:
 
             # Arrange
             config_path = tmp_path / "pyproject.toml"
-            config_path.write_text(dumps(TEST_REPLACE_CONFIG))
+            config_path.write_text(dumps(TEST_REPLACE_CONFIG), encoding="utf-8")
             doc_path = tmp_path / "docs.yaml"
-            doc_path.write_text("We should censor profanity\n\n")
+            doc_path.write_text("We should censor profanity\n\n", encoding="utf-8")
 
             with inside_dir(tmp_path):
                 result: Result = runner.invoke(
@@ -274,9 +279,11 @@ class TestReplaceCLI:
 
             # Arrange
             config_path = tmp_path / "pyproject.toml"
-            config_path.write_text(dumps(TEST_REPLACE_CONFIG))
+            config_path.write_text(dumps(TEST_REPLACE_CONFIG), encoding="utf-8")
             doc_path = tmp_path / "docs.yaml"
-            doc_path.write_text("url: https://github.com/sampleuser/workflows/v2.17.7/.github/update_mailmap.py")
+            doc_path.write_text(
+                "url: https://github.com/sampleuser/workflows/v2.17.7/.github/update_mailmap.py", encoding="utf-8"
+            )
 
             with inside_dir(tmp_path):
                 result: Result = runner.invoke(

--- a/tests/test_config/test_create.py
+++ b/tests/test_config/test_create.py
@@ -50,7 +50,7 @@ class TestGetDefaultsFromDest:
     def test_existing_path_returns_existing_config(self, tmp_path: Path, default_config: dict):
         """If the destination exists, the existing config should be returned."""
         dest_path = tmp_path / "pyproject-1.toml"
-        dest_path.write_text(dumps(BASIC_CONFIG))
+        dest_path.write_text(dumps(BASIC_CONFIG), encoding="utf-8")
 
         with inside_dir(tmp_path):
             config, destination_config = get_defaults_from_dest("pyproject-1.toml")
@@ -73,7 +73,7 @@ class TestGetDefaultsFromDest:
     def test_existing_path_with_no_config_returns_default_config(self, tmp_path: Path, default_config: dict):
         """If the destination exists but has no config, the default config should be returned."""
         dest_path = tmp_path / "pyproject-3.toml"
-        dest_path.write_text(dumps({"tool": {"poetry": {}}}))
+        dest_path.write_text(dumps({"tool": {"poetry": {}}}), encoding="utf-8")
 
         with inside_dir(tmp_path):
             config, destination_config = get_defaults_from_dest("pyproject-3.toml")
@@ -85,7 +85,7 @@ class TestGetDefaultsFromDest:
     def test_existing_path_with_project_version_uses_project_version(self, tmp_path: Path, default_config: dict):
         """If the destination exists and has a project version, the project version should be used as current_version."""
         dest_path = tmp_path / "pyproject-4.toml"
-        dest_path.write_text(dumps({"tool": {"poetry": {}}, "project": {"version": "1.2.3"}}))
+        dest_path.write_text(dumps({"tool": {"poetry": {}}, "project": {"version": "1.2.3"}}), encoding="utf-8")
 
         with inside_dir(tmp_path):
             config, destination_config = get_defaults_from_dest("pyproject-4.toml")

--- a/tests/test_config/test_files.py
+++ b/tests/test_config/test_files.py
@@ -25,7 +25,7 @@ class TestFindConfigFile:
         def test_returns_path_to_existing_file(self, tmp_path: Path) -> None:
             """If an explicit config file is passed, it should be returned."""
             cfg_file = tmp_path / "bump.toml"
-            cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"')
+            cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"', encoding="utf-8")
             assert find_config_file(cfg_file) == cfg_file
 
         def test_returns_none_when_missing_file(self, tmp_path: Path) -> None:
@@ -43,7 +43,7 @@ class TestFindConfigFile:
         def test_returns_path_to_existing_default_file(self, tmp_path: Path, cfg_file_name: str) -> None:
             """If no explicit config file is passed, it returns the path to an existing expected file."""
             cfg_file = tmp_path / cfg_file_name
-            cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"')
+            cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"', encoding="utf-8")
             with inside_dir(tmp_path):
                 assert find_config_file() == cfg_file
 
@@ -57,7 +57,7 @@ class TestFindConfigFile:
             expected_order = list(CONFIG_FILE_SEARCH_ORDER)[:]  # make a copy so we can mutate it
             cfg_file_paths = [tmp_path / cfg_file_name for cfg_file_name in expected_order]
             for cfg_file in cfg_file_paths:  # create all the files
-                cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"')
+                cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"', encoding="utf-8")
 
             with inside_dir(tmp_path):
                 while expected_order:
@@ -101,7 +101,7 @@ class TestReadConfigFile:
             caplog.set_level("INFO")
             tmp_path = tmp_path_factory.mktemp("explicit-file-passed-")
             cfg_file = tmp_path / "basic_cfg.unknown"
-            cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"')
+            cfg_file.write_text('[tool.bumpversion]\ncurrent_version = "1.0.0"', encoding="utf-8")
             with inside_dir(tmp_path):
                 assert config.read_config_file(cfg_file) == {}
             assert "Unknown config file suffix" in caplog.text
@@ -132,9 +132,9 @@ def test_read_toml_file(conf_file: str, expected_file: str, fixtures_path: Path)
 def test_multiple_config_files(tmp_path: Path):
     """If there are multiple config files, the first one with content wins."""
     setup_cfg = tmp_path / "setup.cfg"
-    setup_cfg.write_text("[metadata]\nname: just-a-name\n")
+    setup_cfg.write_text("[metadata]\nname: just-a-name\n", encoding="utf-8")
     bumpversion_cfg = tmp_path / ".bumpversion.cfg"
-    bumpversion_cfg.write_text("\n")
+    bumpversion_cfg.write_text("\n", encoding="utf-8")
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(
         "[tool.bumpversion]\n"
@@ -143,7 +143,8 @@ def test_multiple_config_files(tmp_path: Path):
         "serialize = [\n"
         '    "{major}.{minor}.{patch}-{release}",\n'
         '    "{major}.{minor}.{patch}"\n'
-        "]\n"
+        "]\n",
+        encoding="utf-8",
     )
     with inside_dir(tmp_path):
         cfg_file = bumpversion.config.files.find_config_file()
@@ -180,7 +181,7 @@ def test_update_config_file(tmp_path: Path, cfg_file_name: str, fixtures_path: P
     expected_diff = TOML_EXPECTED_DIFF
     cfg_path = tmp_path / cfg_file_name
     orig_path = fixtures_path / f"basic_cfg{cfg_path.suffix}"
-    cfg_path.write_text(orig_path.read_text())
+    cfg_path.write_text(orig_path.read_text(), encoding="utf-8")
     original_content = orig_path.read_text().splitlines(keepends=True)
     with inside_dir(tmp_path):
         cfg = config.get_configuration(cfg_path)
@@ -206,9 +207,9 @@ def test_pep440_config(git_repo: Path, fixtures_path: Path):
 
     cfg_path = git_repo / "pyproject.toml"
     orig_path = fixtures_path / "pep440.toml"
-    cfg_path.write_text(orig_path.read_text())
+    cfg_path.write_text(orig_path.read_text(), encoding="utf-8")
     version_path = git_repo / "VERSION"
-    version_path.write_text("1.0.0")
+    version_path.write_text("1.0.0", encoding="utf-8")
     readme_path = git_repo / "README.md"
     runner: CliRunner = CliRunner()
 
@@ -225,7 +226,7 @@ def test_pep440_config(git_repo: Path, fixtures_path: Path):
         assert next_version_str == "1.0.1"
 
         subprocess.run(["git", "checkout", "-b", "my-really-LONG-branch_name"], check=True, capture_output=True)
-        readme_path.write_text("This is my branch!")
+        readme_path.write_text("This is my branch!", encoding="utf-8")
         result: Result = runner.invoke(cli.cli, ["bump", "dev_label", "--no-tag"])
         assert result.exit_code == 0
         cfg = config.get_configuration(cfg_path)

--- a/tests/test_config/test_files_legacy.py
+++ b/tests/test_config/test_files_legacy.py
@@ -65,7 +65,8 @@ def test_independent_falsy_value_in_config_does_not_bump_independently(tmp_path:
         [bumpversion:part:build]
         independent = 0
         """
-        )
+        ),
+        encoding="utf-8",
     )
 
     conf = config.get_configuration(config_file)
@@ -113,7 +114,7 @@ def test_update_ini_config_file(tmp_path: Path, cfg_file_name: str, fixtures_pat
     expected_diff = CFG_EXPECTED_DIFF
     cfg_path = tmp_path / cfg_file_name
     orig_path = fixtures_path / f"basic_cfg{cfg_path.suffix}"
-    cfg_path.write_text(orig_path.read_text())
+    cfg_path.write_text(orig_path.read_text(), encoding="utf-8")
     original_content = orig_path.read_text().splitlines(keepends=True)
 
     update_ini_config_file(cfg_path, "1.0.0", "1.0.1")
@@ -133,7 +134,8 @@ def test_file_keyword_with_suffix_is_accepted(tmp_path: Path, cfg_file: str, cfg
         "replace = version {new_version}\n"
         f"[bumpversion:{cfg_file_keyword}:file2]\n"
         "search = The current version is {current_version}\n"
-        "replace = The current version is {new_version}\n"
+        "replace = The current version is {new_version}\n",
+        encoding="utf-8",
     )
     setup_cfg = config.get_configuration(cfg_file_path)
     assert len(setup_cfg.files) == 2

--- a/tests/test_config/test_utils.py
+++ b/tests/test_config/test_utils.py
@@ -22,7 +22,7 @@ def write_config(tmp_path: Path, overrides: dict) -> Path:
     defaults["current_version"] = defaults["current_version"] or "1.2.3"
     defaults["commit_args"] = ""
     config = {"tool": {"bumpversion": {**defaults, **overrides}}}
-    config_file.write_text(tomlkit.dumps(config))
+    config_file.write_text(tomlkit.dumps(config), encoding="utf-8")
     return config_file
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -29,7 +29,7 @@ def test_single_file_processed_twice(tmp_path: Path):
     to verify correct interpretation.
     """
     filepath = tmp_path.joinpath("file2")
-    filepath.write_text("dots: 0.10.2\ndashes: 0-10-2")
+    filepath.write_text("dots: 0.10.2\ndashes: 0-10-2", encoding="utf-8")
     overrides = {
         "current_version": "0.10.2",
         "files": [
@@ -61,13 +61,13 @@ def test_single_file_processed_twice(tmp_path: Path):
 
 def test_multi_file_configuration(tmp_path: Path):
     full_vers_path = tmp_path / "FULL_VERSION.txt"
-    full_vers_path.write_text("1.0.3")
+    full_vers_path.write_text("1.0.3", encoding="utf-8")
     maj_vers_path = tmp_path / "MAJOR_VERSION.txt"
-    maj_vers_path.write_text("1")
+    maj_vers_path.write_text("1", encoding="utf-8")
     readme_path = tmp_path / "README.txt"
-    readme_path.write_text("MyAwesomeSoftware(TM) v1.0")
+    readme_path.write_text("MyAwesomeSoftware(TM) v1.0", encoding="utf-8")
     build_num_path = tmp_path / "BUILD_NUMBER"
-    build_num_path.write_text("1.0.3+joe+38943")
+    build_num_path.write_text("1.0.3+joe+38943", encoding="utf-8")
 
     overrides = {
         "current_version": "1.0.3+joe+38943",
@@ -141,7 +141,7 @@ def test_raises_correct_missing_version_string(tmp_path: Path, fixtures_path: Pa
         conf = config.get_configuration(config_file=dst_path.joinpath(".bumpversion.toml"))
         version_config = VersionConfig(conf.parse, conf.serialize, conf.search, conf.replace, conf.parts)
         current_version = version_config.parse(conf.current_version)
-        dst_path.joinpath("Version.csv").write_text("1;3-1;0;rc;build.1031")
+        dst_path.joinpath("Version.csv").write_text("1;3-1;0;rc;build.1031", encoding="utf-8")
 
         major_version = current_version.bump("patch")
         ctx = get_context(conf)
@@ -179,7 +179,7 @@ def test_search_replace_to_avoid_updating_unconcerned_lines(tmp_path: Path, capl
 
     caplog.set_level(logging.DEBUG)
     req_path = tmp_path / "requirements.txt"
-    req_path.write_text("Django>=1.5.6,<1.6\nMyProject==1.5.6")
+    req_path.write_text("Django>=1.5.6,<1.6\nMyProject==1.5.6", encoding="utf-8")
 
     changelog_path = tmp_path / "CHANGELOG.md"
     changelog_path.write_text(
@@ -196,7 +196,8 @@ def test_search_replace_to_avoid_updating_unconcerned_lines(tmp_path: Path, capl
     - This CHANGELOG file to hopefully serve as an evolving example of a
       standardized open source project CHANGELOG.
     """
-        )
+        ),
+        encoding="utf-8",
     )
 
     overrides = {
@@ -257,7 +258,7 @@ def test_non_matching_search_does_not_modify_file(tmp_path: Path):
     * bullet point B
     """
     )
-    changelog_path.write_text(changelog_content)
+    changelog_path.write_text(changelog_content, encoding="utf-8")
 
     overrides = {
         "current_version": "1.0.3",
@@ -303,7 +304,7 @@ def test_multi_line_search_is_found(tmp_path: Path) -> None:
     """A multiline search string is found and replaced."""
     # Arrange
     alphabet_path = tmp_path / "the_alphabet.txt"
-    alphabet_path.write_text("A\nB\nC\n")
+    alphabet_path.write_text("A\nB\nC\n", encoding="utf-8")
 
     overrides = {
         "current_version": "9.8.7",
@@ -337,7 +338,7 @@ def test_ignore_missing_version(global_value: bool, file_value: bool, should_rai
     """If the version is not found in the file, do nothing."""
     # Arrange
     version_path = tmp_path / Path("VERSION")
-    version_path.write_text("1.2.3")
+    version_path.write_text("1.2.3", encoding="utf-8")
 
     overrides = {
         "current_version": "1.2.5",
@@ -364,7 +365,7 @@ def test_regex_search(tmp_path: Path) -> None:
     """A regex search string is found and replaced."""
     # Arrange
     version_path = tmp_path / "VERSION"
-    version_path.write_text("Release: 1234-56-78 '1.2.3'")
+    version_path.write_text("Release: 1234-56-78 '1.2.3'", encoding="utf-8")
 
     overrides = {
         "regex": True,
@@ -389,7 +390,7 @@ def test_regex_search_with_escaped_chars(tmp_path: Path) -> None:
     """A search that uses special characters is not treated as a regex."""
     # Arrange
     version_path = tmp_path / "VERSION"
-    version_path.write_text("## [Release] 1.2.3 1234-56-78")
+    version_path.write_text("## [Release] 1.2.3 1234-56-78", encoding="utf-8")
 
     overrides = {
         "regex": True,
@@ -414,7 +415,7 @@ def test_regex_search_in_toml(tmp_path: Path, fixtures_path: Path) -> None:
     """Tests how-to doc 'update-a-date.md'."""
     # Arrange
     version_path = tmp_path / "VERSION"
-    version_path.write_text("__date__ = '1234-56-78'\n__version__ = '1.2.3'")
+    version_path.write_text("__date__ = '1234-56-78'\n__version__ = '1.2.3'", encoding="utf-8")
     config_path = tmp_path / ".bumpversion.toml"
     shutil.copyfile(fixtures_path / "replace-date-config.toml", config_path)
     with inside_dir(tmp_path):
@@ -462,7 +463,7 @@ def test_bad_regex_search(tmp_path: Path, caplog) -> None:
     """A search string not meant to be a regex is still found and replaced."""
     # Arrange
     version_path = tmp_path / "VERSION"
-    version_path.write_text("Score: A+ ( '1.2.3'")
+    version_path.write_text("Score: A+ ( '1.2.3'", encoding="utf-8")
 
     overrides = {
         "regex": True,
@@ -490,7 +491,7 @@ class TestDataFileUpdater:
         """A non-TOML file is not modified."""
         # Arrange
         version_path = tmp_path / "VERSION"
-        version_path.write_text("1.2.3")
+        version_path.write_text("1.2.3", encoding="utf-8")
 
         overrides = {"current_version": "1.2.3", "files": [{"filename": str(version_path)}]}
         conf, version_config, current_version = get_config_data(overrides)

--- a/tests/test_scm.py
+++ b/tests/test_scm.py
@@ -119,7 +119,7 @@ def test_commit_and_tag_from_below_scm_root(repo: str, scm_command: str, scm_cla
     # Arrange
     repo_path: Path = request.getfixturevalue(repo)
     version_path = repo_path / "VERSION"
-    version_path.write_text("30.0.3")
+    version_path.write_text("30.0.3", encoding="utf-8")
     sub_dir_path = repo_path / "subdir"
     sub_dir_path.mkdir(exist_ok=True)
 
@@ -133,7 +133,7 @@ def test_commit_and_tag_from_below_scm_root(repo: str, scm_command: str, scm_cla
         subprocess.run([scm_command, "add", "VERSION"], check=True, capture_output=True)
         subprocess.run([scm_command, "commit", "-m", "initial commit"], check=True, capture_output=True)
         with inside_dir(sub_dir_path):
-            version_path.write_text("30.1.0")
+            version_path.write_text("30.1.0", encoding="utf-8")
 
             # Act
             scm_class.commit_to_scm(files=[version_path], config=conf, context=context)
@@ -180,7 +180,7 @@ def test_commit_tag_dry_run_interactions(
     # Arrange
     repo_path: Path = request.getfixturevalue(repo)
     version_path = repo_path / "VERSION"
-    version_path.write_text("30.0.3")
+    version_path.write_text("30.0.3", encoding="utf-8")
 
     overrides = {"current_version": "30.0.3", "commit": commit, "tag": tag, "files": [{"filename": str(version_path)}]}
     context = {
@@ -191,7 +191,7 @@ def test_commit_tag_dry_run_interactions(
         conf, version_config, current_version = get_config_data(overrides)
         subprocess.run([scm_command, "add", "VERSION"], check=True, capture_output=True)
         subprocess.run([scm_command, "commit", "-m", "initial commit"], check=True, capture_output=True)
-        version_path.write_text("30.1.0")
+        version_path.write_text("30.1.0", encoding="utf-8")
         # Act
         scm_class.commit_to_scm(files=[version_path], config=conf, context=context, dry_run=dry_run)
         scm_class.tag_in_scm(config=conf, context=context, dry_run=dry_run)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -57,7 +57,7 @@ class TestVisualize:
         """Test that the correct string is returned."""
         config_content = fixtures_path.joinpath("basic_cfg.toml").read_text()
         config_path = tmp_path.joinpath(".bumpversion-1.toml")
-        config_path.write_text(config_content)
+        config_path.write_text(config_content, encoding="utf-8")
         config = get_configuration(config_path)
         visualize(config, "1.0.0")
         captured = capsys.readouterr()

--- a/tools/update_frontmatter.py
+++ b/tools/update_frontmatter.py
@@ -58,7 +58,7 @@ def process_file(markdown_path: Path) -> None:
             post[key] = value
         new_text = frontmatter.dumps(post)
         print(f"Updating {markdown_path}")  # noqa: T201
-        markdown_path.write_text(new_text)
+        markdown_path.write_text(new_text, encoding="utf-8")
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
Fixes #157 

The problem was that it failed to write the configuration file because of a character-encoding problem. This forces all writes to use UTF-8.