### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,7 +580,7 @@ dependency-group: github-actions
     
   - Fixes #61
   - Config now includes `resolved_filemap` property
-  - resolved filemap exapands all globs
+  - resolved filemap expands all globs
   - Config now includes `files_to_modify` property
   - files to modify resolves inclusions and exclutions
   - Improved Config.add_files property
@@ -826,7 +826,7 @@ dependency-group: github-actions
     
 - Fixed issue with formatting. [da7544f](https://github.com/callowayproject/bump-my-version/commit/da7544f18780d5f289381d33a87b331c3eaf4d6b)
     
-  There is an underlying edge case where the deriving previous environment variables with multple ways of formatting version numbers will fail.
+  There is an underlying edge case where the deriving previous environment variables with multiple ways of formatting version numbers will fail.
 ### New
 
 - Add test to reproduce issue #14. [d78ff46](https://github.com/callowayproject/bump-my-version/commit/d78ff46d65ce75b7651e5697eef59dbcb71c935e)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ parse = """(?x)
     (?P<minor>0|[1-9]\\d*)\\.
     (?P<patch>0|[1-9]\\d*)
     (?:
-        -                             # dash seperator for pre-release section
+        -                             # dash separator for pre-release section
         (?P<pre_l>[a-zA-Z-]+)         # pre-release label
         (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
     )?                                # pre-release section is optional

--- a/bumpversion/autocast.py
+++ b/bumpversion/autocast.py
@@ -28,7 +28,7 @@ def noneify(s: str) -> None:
 
 def listify(s: str) -> list:
     """
-    Convert a string representation of a list into list of homogenous basic types.
+    Convert a string representation of a list into list of homogeneous basic types.
 
     Type of elements in list is determined via first element. Successive elements are
     cast to that type.
@@ -38,10 +38,10 @@ def listify(s: str) -> list:
 
     Raises:
         ValueError: If string does not represent a list.
-        TypeError: If string does not represent a list of homogenous basic types.
+        TypeError: If string does not represent a list of homogeneous basic types.
 
     Returns:
-        List of homogenous basic types.
+        List of homogeneous basic types.
     """
     if "\n" in s:
         str_list = s.strip().split("\n")

--- a/bumpversion/versioning/conventions.py
+++ b/bumpversion/versioning/conventions.py
@@ -77,12 +77,12 @@ SEMVER_PATTERN = r"""
     (?P<minor>0|[1-9]\d*)\.
     (?P<patch>0|[1-9]\d*)
     (?:
-        -                             # dash seperator for pre-release section
+        -                             # dash separator for pre-release section
         (?P<pre_l>[a-zA-Z-]+)         # pre-release label
         (?P<pre_n>0|[1-9]\d*)         # pre-release version number
     )?                                # pre-release section is optional
     (?:
-        \+                            # plus seperator for build metadata section
+        \+                            # plus separator for build metadata section
         (?P<buildmetadata>
             [0-9a-zA-Z-]+
             (?:\.[0-9a-zA-Z-]+)*

--- a/tests/test_cli/test_show.py
+++ b/tests/test_cli/test_show.py
@@ -26,7 +26,7 @@ def test_show(tmp_path: Path, fixtures_path: Path, runner):
 
 
 def test_show_and_increment(tmp_path: Path, fixtures_path: Path, runner):
-    """The show subcommand should incrment the version and display it."""
+    """The show subcommand should increment the version and display it."""
     # Arrange
     config_path = tmp_path / "pyproject.toml"
     toml_path = fixtures_path / "basic_cfg.toml"


### PR DESCRIPTION
`codespell --ignore-words-list=astroid --write-changes .`
* https://pypi.org/project/codespell