### PR TITLE
pre-commit: Discover typos with codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,13 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+    - id: codespell
+      additional_dependencies:
+        - tomli
+      args: [--ignore-words-list, astroid ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:


### PR DESCRIPTION
Related to:
* #168
```
codespell................................................................Failed
- hook id: codespell
- exit code: 65

CHANGELOG.md:583: exapands ==> expands
CHANGELOG.md:829: multple ==> multiple
bumpversion/autocast.py:31: homogenous ==> homogeneous
bumpversion/autocast.py:41: homogenous ==> homogeneous
bumpversion/autocast.py:44: homogenous ==> homogeneous
README.md:103: seperator ==> separator
tests/test_cli/test_show.py:29: incrment ==> increment
bumpversion/versioning/conventions.py:80: seperator ==> separator
bumpversion/versioning/conventions.py:85: seperator ==> separator
```