### PR TITLE
Fix JSON serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased (2024-08-08)
+[Compare the full difference.](https://github.com/callowayproject/bump-my-version/compare/0.25.1...HEAD)
+
+### Fixes
+
+- Fix JSON serialization. [d3f3022](https://github.com/callowayproject/bump-my-version/commit/d3f3022bd4c8b8d6e41fa7b5b6ccfc2aa6cf7878)
+    
+  Extended the default_encoder function to handle Path objects by converting them to their string representation. This ensures that Path objects can be properly serialized to JSON format.
+
+## 0.25.1 (2024-08-07)
+[Compare the full difference.](https://github.com/callowayproject/bump-my-version/compare/0.25.0...0.25.1)
+
+### Fixes
+
+- Fixes mypy pre-commit checking. [f7d0909](https://github.com/callowayproject/bump-my-version/commit/f7d0909deb8d0cf06607c4d51090ca23f7d92664)
+    
+- Fixes repository path checks. [ff3f72a](https://github.com/callowayproject/bump-my-version/commit/ff3f72a9a922dfbb61eea9325fc9dba7c12c7f62)
+    
+  Checked for relative paths when determining if the file was part of the repo or not.
+- Fixed test to use globs. [72f9841](https://github.com/callowayproject/bump-my-version/commit/72f9841a9628e26c6cf06518b0428d3990a08421)
+    
+### Other
+
+- [pre-commit.ci] pre-commit autoupdate. [58cc73e](https://github.com/callowayproject/bump-my-version/commit/58cc73ed041f978fddd9f81e995901596f6ac722)
+    
+  **updates:** - [github.com/astral-sh/ruff-pre-commit: v0.5.5 → v0.5.6](https://github.com/astral-sh/ruff-pre-commit/compare/v0.5.5...v0.5.6)
+
+
 ## 0.25.0 (2024-08-06)
 [Compare the full difference.](https://github.com/callowayproject/bump-my-version/compare/0.24.3...0.25.0)
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for bump-my-version."""
 
-__version__: str = "0.25.0"
+__version__: str = "0.25.1"

--- a/bumpversion/show.py
+++ b/bumpversion/show.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 from io import StringIO
+from pathlib import Path
 from pprint import pprint
 from typing import Any, Optional
 
@@ -39,6 +40,8 @@ def output_json(value: dict) -> None:
             return str(obj)
         elif isinstance(obj, type):
             return obj.__name__
+        elif isinstance(obj, Path):
+            return str(obj)
         raise TypeError(f"Object of type {type(obj), str(obj)} is not JSON serializable")
 
     print_info(json.dumps(value, sort_keys=True, indent=2, default=default_encoder))


### PR DESCRIPTION
Extended the default_encoder function to handle Path objects by converting them to their string representation. This ensures that Path objects can be properly serialized to JSON format.