### PR TITLE
Add `inputs` section in GHA workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ name: Bump version
 
 on:
   workflow_dispatch:
+    inputs:
       bump-type:
         description: 'Bump type'
         required: true


### PR DESCRIPTION
Not sure whether the `inputs` section is needed in the GHA workflow but when trying to use it, I get this:
![image](https://github.com/user-attachments/assets/892b746e-f8cf-4dc7-b375-c29247d177c6)

