### PR TITLE
Output hooks scripts by default

### DIFF
--- a/bumpversion/hooks.py
+++ b/bumpversion/hooks.py
@@ -97,9 +97,9 @@ def run_hooks(hooks: List[str], env: Dict[str, str], dry_run: bool = False) -> N
     logger.indent()
     for script in hooks:
         if dry_run:
-            logger.debug(f"Would run {script!r}")
+            logger.info(f"Would run {script!r}")
             continue
-        logger.debug(f"Running {script!r}")
+        logger.info(f"Running {script!r}")
         logger.indent()
         result = run_command(script, env)
         if result.returncode != 0:

--- a/tests/test_hooks/test_run_hook_suites.py
+++ b/tests/test_hooks/test_run_hook_suites.py
@@ -63,7 +63,12 @@ class TestHookSuites:
         suite_func(config, *suite_args)
 
         # Assert
-        mock_logger.info.assert_called_once_with(f"Running {suite_name} hooks:".replace("_", "-"))
+        expected_info_calls = [
+            mocker.call(f"Running {suite_name} hooks:".replace("_", "-")),
+            mocker.call("Running 'script1'"),
+            mocker.call("Running 'script2'"),
+        ]
+        mock_logger.info.assert_has_calls(expected_info_calls)
         mock_env.assert_called_once_with(config, *suite_args)
         expected_run_command_calls = [
             mocker.call("script1", env),

--- a/tests/test_hooks/test_run_hooks.py
+++ b/tests/test_hooks/test_run_hooks.py
@@ -19,17 +19,20 @@ def test_calls_each_hook(mocker):
     hooks.run_hooks(hooks_list, env)
 
     # Assert
-    expected_calls = [
+    expected_info_calls = [
         mocker.call("Running 'script1'"),
+        mocker.call("Running 'script2'"),
+    ]
+    mock_logger.info.assert_has_calls(expected_info_calls)
+    expected_debug_calls = [
         mocker.call("Exited with 0"),
         mocker.call("output"),
         mocker.call("error"),
-        mocker.call("Running 'script2'"),
         mocker.call("Exited with 0"),
         mocker.call("output"),
         mocker.call("error"),
     ]
-    mock_logger.debug.assert_has_calls(expected_calls)
+    mock_logger.debug.assert_has_calls(expected_debug_calls)
     mock_run_command.assert_any_call("script1", env)
     mock_run_command.assert_any_call("script2", env)
 
@@ -48,9 +51,9 @@ def test_raises_exception_if_hook_fails(mocker):
         hooks.run_hooks(hooks_list, env)
 
     # Assert
-    expected_debug_calls = [mocker.call("Running 'script1'")]
+    expected_info_calls = [mocker.call("Running 'script1'")]
     expected_warning_calls = [mocker.call("output"), mocker.call("error")]
-    mock_logger.debug.assert_has_calls(expected_debug_calls)
+    mock_logger.info.assert_has_calls(expected_info_calls)
     mock_logger.warning.assert_has_calls(expected_warning_calls)
     mock_run_command.assert_any_call("script1", env)
 
@@ -68,5 +71,5 @@ def test_does_not_call_each_hook_when_dry_run(mocker):
 
     # Assert
     expected_calls = [mocker.call("Would run 'script1'"), mocker.call("Would run 'script2'")]
-    mock_logger.debug.assert_has_calls(expected_calls)
+    mock_logger.info.assert_has_calls(expected_calls)
     mock_run_command.assert_not_called()


### PR DESCRIPTION
I noticed hooks are not printed in the output. I've updated the hooks output, so the individual hooks are printed to output by default.