### PR TITLE
Skip scm tests if the command is not installed

### DIFF
--- a/tests/test_cli/test_bump.py
+++ b/tests/test_cli/test_bump.py
@@ -155,8 +155,18 @@ def test_cli_options_override_config(tmp_path: Path, fixtures_path: Path, mocker
 @pytest.mark.parametrize(
     ["repo", "scm_command"],
     [
-        param("git_repo", "git", id="git"),
-        param("hg_repo", "hg", id="hg"),
+        param(
+            "git_repo",
+            "git",
+            id="git",
+            marks=pytest.mark.skipif(not shutil.which("git"), reason="Git is not available."),
+        ),
+        param(
+            "hg_repo",
+            "hg",
+            id="hg",
+            marks=pytest.mark.skipif(not shutil.which("hg"), reason="Mercurial is not available."),
+        ),
     ],
 )
 def test_dirty_work_dir_raises_error(repo: str, scm_command: str, request, runner):

--- a/tests/test_scm.py
+++ b/tests/test_scm.py
@@ -1,6 +1,7 @@
 """Tests of the VCS module."""
 
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -176,6 +177,7 @@ def test_hg_is_not_usable(tmp_path: Path) -> None:
         assert not scm.Mercurial.is_usable()
 
 
+@pytest.mark.skipif(not shutil.which("hg"), reason="Mercurial is not available.")
 def test_hg_is_usable(hg_repo: Path) -> None:
     """Should return false if it is not a mercurial repo."""
     with inside_dir(hg_repo):
@@ -185,8 +187,20 @@ def test_hg_is_usable(hg_repo: Path) -> None:
 @pytest.mark.parametrize(
     ["repo", "scm_command", "scm_class"],
     [
-        param("git_repo", "git", scm.Git, id="git"),
-        param("hg_repo", "hg", scm.Mercurial, id="hg"),
+        param(
+            "git_repo",
+            "git",
+            scm.Git,
+            id="git",
+            marks=pytest.mark.skipif(not shutil.which("git"), reason="Git is not available."),
+        ),
+        param(
+            "hg_repo",
+            "hg",
+            scm.Mercurial,
+            id="hg",
+            marks=pytest.mark.skipif(not shutil.which("hg"), reason="Mercurial is not available."),
+        ),
     ],
 )
 def test_commit_and_tag_from_below_scm_root(repo: str, scm_command: str, scm_class: scm.SourceCodeManager, request):
@@ -226,8 +240,20 @@ def test_commit_and_tag_from_below_scm_root(repo: str, scm_command: str, scm_cla
 @pytest.mark.parametrize(
     ["repo", "scm_command", "scm_class"],
     [
-        param("git_repo", "git", scm.Git, id="git"),
-        param("hg_repo", "hg", scm.Mercurial, id="hg"),
+        param(
+            "git_repo",
+            "git",
+            scm.Git,
+            id="git",
+            marks=pytest.mark.skipif(not shutil.which("git"), reason="Git is not available."),
+        ),
+        param(
+            "hg_repo",
+            "hg",
+            scm.Mercurial,
+            id="hg",
+            marks=pytest.mark.skipif(not shutil.which("hg"), reason="Mercurial is not available."),
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Skip SCM tests for git/mercurial if the respective command is not available.