### PR TITLE
Fix format arg help text for show command

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -327,7 +327,7 @@ def bump(
     envvar="BUMPVERSION_FORMAT",
     type=click.Choice(["default", "yaml", "json"], case_sensitive=False),
     default="default",
-    help="Config file to read most of the variables from.",
+    help="Specify the output format.",
 )
 @click.option(
     "-i",


### PR DESCRIPTION
Hi,

I think I saw an error in the `show` CLI command, where the `format` argument's help text looked like a remaining copy-paste.

I hope this helps!