### PR TITLE
Update setup section in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,8 @@ cd bump-my-version
 python -m venv env
 source env/bin/activate
 
-# Install the development requirements
-python -m pip install -r requirements/dev.txt
+# Install the project in editable mode with its optional dependencies
+python -m pip install -e .[dev,test]
 ```
 
 ### Run tests


### PR DESCRIPTION
Hi again,

I think the setup instructions in CONTRIBUTING.md were outdated since the requirements txt files were removed in previous commits.

I hope this helps!