### PR TITLE
Fixes #284. Add UTF-8 encoding to subprocess.run in run_command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   pull_request:

--- a/bumpversion/utils.py
+++ b/bumpversion/utils.py
@@ -124,7 +124,9 @@ def format_and_raise_error(exc: Union[TypeError, subprocess.CalledProcessError])
 
 def run_command(command: list, env: Optional[dict] = None) -> CompletedProcess:
     """Run a shell command and return its output."""
-    result = subprocess.run(command, text=True, check=True, capture_output=True, env=env)  # NOQA: S603
+    result = subprocess.run(  # NOQA: S603
+        command, text=True, check=True, capture_output=True, env=env, encoding="utf-8"
+    )
     result.check_returncode()
     return result
 

--- a/bumpversion/utils.py
+++ b/bumpversion/utils.py
@@ -131,7 +131,7 @@ def run_command(command: list, env: Optional[dict] = None) -> CompletedProcess:
     return result
 
 
-def is_subpath(parent: Path | str, path: Path | str) -> bool:
+def is_subpath(parent: Union[Path, str], path: Union[Path, str]) -> bool:
     """Return whether a path is inside the parent."""
     normalized_parent = Path(parent)
     normalized_path = Path(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,18 +16,18 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Version Control",
     "Topic :: System :: Software Distribution",
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 keywords = ["bumpversion", "version", "release"]
 dynamic = ["version"]


### PR DESCRIPTION
Explicitly set the encoding to "utf-8" in the subprocess.run call to ensure consistent handling of command output. This prevents potential encoding-related issues when processing command results.