### PR TITLE
Fix #388 - `python3.8` type hint compatibility

### DIFF
--- a/bumpversion/utils.py
+++ b/bumpversion/utils.py
@@ -1,5 +1,7 @@
 """General utilities."""
 
+from __future__ import annotations
+
 import string
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
This should address the following error when running `bump-my-version` in a `python3.8` environment:

```
    def is_subpath(parent: Path | str, path: Path | str) -> bool:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

#288 