### PR TITLE
370-breaks-under-click830

### DIFF
--- a/bumpversion/utils.py
+++ b/bumpversion/utils.py
@@ -138,7 +138,20 @@ def run_command(command: list, env: Optional[dict] = None) -> CompletedProcess:
 
 
 def is_subpath(parent: Pathlike, path: Pathlike) -> bool:
-    """Return whether a path is inside the parent."""
+    """
+    Determines if a given path is a subpath of a specified parent path.
+
+    The function normalizes the inputs as Path objects and checks if the normalized path starts
+    with the normalized parent path as a prefix. For relative paths, the function assumes the path
+    could be within the parent and returns True.
+
+    Args:
+        parent: A Pathlike object representing the parent directory or path.
+        path: A Pathlike object representing the path to check.
+
+    Returns:
+        True if the path is a subpath of the parent, or if it is a relative path; otherwise, False.
+    """
     normalized_parent = Path(parent)
     normalized_path = Path(path)
     return str(normalized_path).startswith(str(normalized_parent)) if normalized_path.is_absolute() else True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
 [build-system]
-requires      = ["hatchling"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
 name = "bump-my-version"
 description = "Version bump your Python project"
-authors = [{ name = "Corey Oordt", email = "coreyoordt@gmail.com" }]
+authors = [
+    { name = "Corey Oordt", email = "coreyoordt@gmail.com" }
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -46,8 +48,8 @@ dependencies = [
 bump-my-version = "bumpversion.cli:cli"
 
 [project.urls]
-homepage      = "https://github.com/callowayproject/bump-my-version"
-repository    = "https://github.com/callowayproject/bump-my-version.git"
+homepage = "https://github.com/callowayproject/bump-my-version"
+repository = "https://github.com/callowayproject/bump-my-version.git"
 documentation = "https://callowayproject.github.io/bump-my-version/"
 
 [dependency-groups]
@@ -56,12 +58,6 @@ dev = [
     "generate-changelog>=0.7.6",
     "pip-tools",
     "pre-commit",
-    "pytest>=8.3.5",
-    "pytest-cov>=3.0.0",
-    "freezegun>=1.5.5",
-    "pytest-mock>=3.14.1",
-    "httpserver>=1.1.0",
-    "pytest-httpserver>=1.1.1",
 ]
 docs = [
     "black",
@@ -82,7 +78,11 @@ docs = [
 ]
 test = [
     "coverage",
+    "freezegun",
     "pre-commit",
+    "pytest-cov",
+    "pytest",
+    "pytest-mock",
     "pytest-sugar",
     "pytest-localserver>=0.9.0.post0",
 ]
@@ -95,10 +95,14 @@ packages = ["bumpversion"]
 
 [tool.coverage.run]
 branch = true
-omit   = ["**/test_*.py", "**/__main__.py", "**/aliases.py"]
+omit = ["**/test_*.py", "**/__main__.py", "**/aliases.py"]
 
 [tool.coverage.report]
-omit = ["*site-packages*", "*tests*", "*.tox*"]
+omit = [
+    "*site-packages*",
+    "*tests*",
+    "*.tox*",
+]
 show_missing = true
 exclude_also = [
     "raise NotImplementedError",
@@ -136,23 +140,23 @@ addopts = [
 ]
 
 [tool.interrogate]
-ignore-init-method         = true
-ignore-init-module         = false
-ignore-magic               = true
-ignore-semiprivate         = false
-ignore-private             = false
+ignore-init-method = true
+ignore-init-module = false
+ignore-magic = true
+ignore-semiprivate = false
+ignore-private = false
 ignore-property-decorators = false
-ignore-module              = false
-ignore-nested-functions    = true
-ignore-nested-classes      = true
-ignore-setters             = false
-fail-under                 = 95
-exclude                    = ["setup.py", "docs", "build"]
-ignore-regex               = ["^get$", "^mock_.*", ".*BaseClass.*"]
-verbose                    = 0
-quiet                      = false
-whitelist-regex            = []
-color                      = true
+ignore-module = false
+ignore-nested-functions = true
+ignore-nested-classes = true
+ignore-setters = false
+fail-under = 95
+exclude = ["setup.py", "docs", "build"]
+ignore-regex = ["^get$", "^mock_.*", ".*BaseClass.*"]
+verbose = 0
+quiet = false
+whitelist-regex = []
+color = true
 
 [tool.black]
 line-length = 119
@@ -227,7 +231,7 @@ ignore = [
     "PLW1641", # eq-without-hash
 ]
 
-fixable   = ["ALL"]
+fixable = ["ALL"]
 unfixable = []
 
 # Allow unused variables when underscore-prefixed.
@@ -274,9 +278,9 @@ order-by-type = true
 convention = "google"
 
 [tool.ruff.lint.flake8-annotations]
-allow-star-arg-any      = true
-mypy-init-return        = true
-suppress-dummy-args     = true
+allow-star-arg-any = true
+mypy-init-return = true
+suppress-dummy-args = true
 suppress-none-returning = true
 
 [tool.bumpversion]
@@ -285,7 +289,10 @@ commit = true
 commit_args = "--no-verify"
 tag = true
 tag_name = "{new_version}"
-moveable_tags = ["v{new_major}", "v{new_major}.{new_minor}"]
+moveable_tags = [
+    "v{new_major}",
+    "v{new_major}.{new_minor}",
+]
 allow_dirty = true
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.(?P<dev>post)\\d+\\.dev\\d+)?"
 serialize = [
@@ -303,33 +310,33 @@ filename = "bumpversion/__init__.py"
 
 [[tool.bumpversion.files]]
 filename = "CHANGELOG.md"
-search   = "Unreleased"
+search = "Unreleased"
 
 [[tool.bumpversion.files]]
 filename = "CHANGELOG.md"
-search   = "{current_version}...HEAD"
-replace  = "{current_version}...{new_version}"
+search = "{current_version}...HEAD"
+replace = "{current_version}...{new_version}"
 
 [[tool.bumpversion.files]]
 filename = "action.yml"
-search   = "bump-my-version=={current_version}"
-replace  = "bump-my-version=={new_version}"
+search = "bump-my-version=={current_version}"
+replace = "bump-my-version=={new_version}"
 
 [[tool.bumpversion.files]]
 filename = "Dockerfile"
-search   = "created=\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}Z"
-replace  = "created={utcnow:%Y-%m-%dT%H:%M:%SZ}"
-regex    = true
+search = "created=\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}Z"
+replace = "created={utcnow:%Y-%m-%dT%H:%M:%SZ}"
+regex = true
 
 [[tool.bumpversion.files]]
 filename = "Dockerfile"
 
 [tool.pydoclint]
-style                                         = "google"
-exclude                                       = '\.git|tests'
+style = "google"
+exclude = '\.git|tests'
 require-return-section-when-returning-nothing = false
-arg-type-hints-in-docstring                   = false
-check-return-types                            = false
-skip-checking-raises                          = true
-quiet                                         = true
-check-class-attributes                        = false
+arg-type-hints-in-docstring = false
+check-return-types = false
+skip-checking-raises = true
+quiet = true
+check-class-attributes = false

--- a/tests/test_click_config.py
+++ b/tests/test_click_config.py
@@ -48,11 +48,14 @@ class TestConfigOption:
 
     def test_passing_url_returns_path(self, runner, fixtures_path: Path, httpserver):
         """Passing an existing file path should return a Path object."""
+        # Assemble
         config = fixtures_path.joinpath("basic_cfg.toml").read_text()
-        httpserver.expect_request("/basic_cfg.toml").respond_with_data(config)
+        httpserver.serve_content(config)
 
-        result = runner.invoke(hello, ["--config", f"http://{httpserver.host}:{httpserver.port}/basic_cfg.toml"])
+        # Act
+        result = runner.invoke(hello, ["--config", f"{httpserver.url}/basic_cfg.toml"])
 
+        # Assert
         assert result.exit_code == 0
         assert "path exists: True" in result.output
 
@@ -69,12 +72,15 @@ class TestResolveConfLocation:
 
     def test_resolves_valid_url(self, fixtures_path: Path, httpserver):
         """Should download the file if given a valid URL."""
+        # Arrange
         config = fixtures_path.joinpath("basic_cfg.toml").read_text()
-        httpserver.expect_request("/basic_cfg.toml").respond_with_data(config)
-        url = f"http://{httpserver.host}:{httpserver.port}/basic_cfg.toml"
+        httpserver.serve_content(config)
+        url = f"{httpserver.url}/basic_cfg.toml"
 
+        # Act
         result = resolve_conf_location(url)
 
+        # Assert
         assert isinstance(result, Path)
         assert result.read_text() == config
 
@@ -84,12 +90,15 @@ class TestDownloadUrl:
 
     def test_download_url_success(self, fixtures_path: Path, httpserver):
         """Should return a Path for a valid request."""
+        # Arrange
         config = fixtures_path.joinpath("basic_cfg.toml").read_text()
-        httpserver.expect_request("/basic_cfg.toml").respond_with_data(config)
-        url = f"http://{httpserver.host}:{httpserver.port}/basic_cfg.toml"
+        httpserver.serve_content(config)
+        url = f"{httpserver.url}/basic_cfg.toml"
 
+        # Act
         result = download_url(url)
 
+        # Assert
         assert isinstance(result, Path)
         assert result.read_text() == config
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
@@ -322,22 +322,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "freezegun" },
     { name = "generate-changelog", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "generate-changelog", version = "0.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "git-fame" },
-    { name = "httpserver" },
     { name = "pip-tools" },
     { name = "pre-commit", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-cov", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pytest-httpserver", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-httpserver", version = "1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pytest-mock", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-mock", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 docs = [
     { name = "black", version = "24.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -364,9 +354,16 @@ docs = [
 test = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "freezegun" },
     { name = "pre-commit", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-cov", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-localserver" },
+    { name = "pytest-mock", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-mock", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-sugar" },
 ]
 
@@ -385,16 +382,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "freezegun", specifier = ">=1.5.5" },
     { name = "generate-changelog", specifier = ">=0.7.6" },
     { name = "git-fame", specifier = ">=1.12.2" },
-    { name = "httpserver", specifier = ">=1.1.0" },
     { name = "pip-tools" },
     { name = "pre-commit" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-cov", specifier = ">=3.0.0" },
-    { name = "pytest-httpserver", specifier = ">=1.1.1" },
-    { name = "pytest-mock", specifier = ">=3.14.1" },
 ]
 docs = [
     { name = "black" },
@@ -415,8 +406,12 @@ docs = [
 ]
 test = [
     { name = "coverage" },
+    { name = "freezegun" },
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-localserver", specifier = ">=0.9.0.post0" },
+    { name = "pytest-mock" },
     { name = "pytest-sugar" },
 ]
 
@@ -1024,12 +1019,6 @@ wheels = [
 ]
 
 [[package]]
-name = "docopt"
-version = "0.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1264,18 +1253,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpserver"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docopt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/b5/f8501d4c763c283ebe108aaa278238c16fdb36fa3cca2419ce9ac709527d/httpserver-1.1.0.tar.gz", hash = "sha256:5bc3daf82512f2f0b311cca68d8ea7a3918c7520d266ce1b8660ed46c478c2e0", size = 104194, upload-time = "2015-04-02T11:23:00.25Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1e/d8d4bed911b0ef911863c8b06dc2b3f1748980703eaacce846ccda73301b/httpserver-1.1.0-py2.py3-none-any.whl", hash = "sha256:ed8845192b1b282753e529feed054b0ccc7a7ab64a8e9632b13cc73108eeb30c", size = 7819, upload-time = "2015-04-02T11:23:04.661Z" },
-]
-
-[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1352,7 +1329,7 @@ resolution-markers = [
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
-    { name = "zipp", version = "3.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "zipp", version = "3.23.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.9' and python_full_version < '3.14') or (python_full_version >= '3.9' and platform_python_implementation == 'PyPy')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -2919,39 +2896,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
-]
-
-[[package]]
-name = "pytest-httpserver"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "werkzeug", version = "3.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/8a/98d9f2dc6a7f486bc3467935db766255509ffd47efc6b47bd2231b2bf009/pytest_httpserver-1.1.1.tar.gz", hash = "sha256:e5c46c62c0aa65e5d4331228cb2cb7db846c36e429c3e74ca806f284806bf7c6", size = 68190, upload-time = "2025-01-21T19:43:36.092Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/52/b9148e455166fba9bc2f6a5293d7d01e305155231d9863f10cb4e968c4fb/pytest_httpserver-1.1.1-py3-none-any.whl", hash = "sha256:aadc744bfac773a2ea93d05c2ef51fa23c087e3cc5dace3ea9d45cdd4bfe1fe8", size = 20723, upload-time = "2025-01-21T19:43:33.801Z" },
-]
-
-[[package]]
-name = "pytest-httpserver"
-version = "1.1.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.10' and python_full_version < '3.14' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.10' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.9.*'",
-]
-dependencies = [
-    { name = "werkzeug", version = "3.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
From @Kugeleis : To circumvent the current [breaking change from click 8.3](https://github.com/pallets/click/issues/3065) I set it to "click<8.3". To make pytest run I had to move dependencies to dev (my uv did not work with group test). I also adjusted some modern API canges for pytest-httpserver.