### PR TITLE
Fix outdated link URL in docs leading to a 404

### DIFF
--- a/.changelog-config.yaml
+++ b/.changelog-config.yaml
@@ -1,4 +1,4 @@
-# For more configuration information, please see https://coordt.github.io/generate-changelog/
+# For more configuration information, please see https://callowayproject.github.io/generate-changelog/
 
 # User variables for reference in other parts of the configuration.
 variables:


### PR DESCRIPTION
Closes #362.

Very minor documentation change, tested and confirmed the new link works now:

<img width="2559" height="1317" alt="screenshot_from_2025_10_12_22_49_10" src="https://github.com/user-attachments/assets/8331fd1e-92fd-4f56-a274-e40da3a13c04" />
