### PR TITLE
Added version placeholders in hook commands for safe execution

### DIFF
--- a/bumpversion/hooks.py
+++ b/bumpversion/hooks.py
@@ -86,6 +86,42 @@ def new_version_env(config: Config, current_version: Version, new_version: Versi
     return {f"{PREFIX}NEW_VERSION": new_version_string, f"{PREFIX}NEW_VERSION_TAG": new_version_tag}
 
 
+def hook_context(config: Config, current_version: Version, new_version: Optional[Version] = None) -> Dict[str, str]:
+    """
+    Build a context dictionary for formatting hook command strings.
+
+    Only version-related keys are included so that unrelated braces in a hook
+    command are not accidentally substituted.
+    """
+    ctx: Dict[str, str] = {"current_version": config.current_version or ""}
+    for part in current_version:
+        ctx[f"current_{part}"] = current_version[part].value
+
+    if new_version is not None:
+        base_ctx = get_context(config, current_version, new_version)
+        ctx["new_version"] = config.version_config.serialize(new_version, base_ctx)
+        for part in new_version:
+            ctx[f"new_{part}"] = new_version[part].value
+
+    return ctx
+
+
+def format_hooks(hooks: List[str], context: Dict[str, str]) -> List[str]:
+    """
+    Replace known version placeholders in hook command strings.
+
+    Placeholders that do not match a key in ``context`` are left untouched.
+    """
+    if not context:
+        return hooks
+
+    def replace_match(match: re.Match) -> str:
+        key = match.group(1)
+        return str(context[key]) if key in context else match.group(0)
+
+    return [re.sub(r"\{(\w+)\}", replace_match, hook) for hook in hooks]
+
+
 def get_setup_hook_env(config: Config, current_version: Version) -> Dict[str, str]:
     """Provide the environment dictionary for `setup_hook`s."""
     return {**base_env(config), **scm_env(config), **version_env(current_version, "CURRENT_")}
@@ -113,8 +149,17 @@ def get_post_commit_hook_env(config: Config, current_version: Version, new_versi
     }
 
 
-def run_hooks(hooks: List[str], env: Dict[str, str], dry_run: bool = False, allow_shell_hooks: bool = False) -> None:
+def run_hooks(
+    hooks: List[str],
+    env: Dict[str, str],
+    dry_run: bool = False,
+    allow_shell_hooks: bool = False,
+    context: Optional[Dict[str, str]] = None,
+) -> None:
     """Run a list of command-line programs, defaulting to safe argv-based execution."""
+    if context is not None and not allow_shell_hooks:
+        hooks = format_hooks(hooks, context)
+
     logger.indent()
     for script in hooks:
         if dry_run:
@@ -157,7 +202,13 @@ def run_setup_hooks(config: Config, current_version: Version, dry_run: bool = Fa
         logger.info("No setup hooks defined")
         return
 
-    run_hooks(config.setup_hooks, env, dry_run, allow_shell_hooks=config.allow_shell_hooks)
+    run_hooks(
+        config.setup_hooks,
+        env,
+        dry_run,
+        allow_shell_hooks=config.allow_shell_hooks,
+        context=hook_context(config, current_version),
+    )
 
 
 def run_pre_commit_hooks(
@@ -173,7 +224,13 @@ def run_pre_commit_hooks(
         logger.info("No pre-commit hooks defined")
         return
 
-    run_hooks(config.pre_commit_hooks, env, dry_run, allow_shell_hooks=config.allow_shell_hooks)
+    run_hooks(
+        config.pre_commit_hooks,
+        env,
+        dry_run,
+        allow_shell_hooks=config.allow_shell_hooks,
+        context=hook_context(config, current_version, new_version),
+    )
 
 
 def run_post_commit_hooks(
@@ -188,4 +245,10 @@ def run_post_commit_hooks(
         logger.info("No post-commit hooks defined")
         return
 
-    run_hooks(config.post_commit_hooks, env, dry_run, allow_shell_hooks=config.allow_shell_hooks)
+    run_hooks(
+        config.post_commit_hooks,
+        env,
+        dry_run,
+        allow_shell_hooks=config.allow_shell_hooks,
+        context=hook_context(config, current_version, new_version),
+    )

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -207,6 +207,35 @@ All environment variables set before bump-my-version was run are available.
 
 ///
 
+### Version placeholders in hook commands
+
+Hook command strings may contain version placeholders that bump-my-version replaces before executing the hook. This works with safe argv-based execution, so you do not need to enable `allow_shell_hooks` to use them.
+
+!!! Note
+
+    Placeholders are only substituted when `allow_shell_hooks` is `false` (the default). When `allow_shell_hooks` is `true`, hook commands are passed through unchanged so that shell variable expansion (`$BVHOOK_NEW_VERSION`) can be used instead.
+
+The following placeholders are available:
+
+| Placeholder | Value | Available in |
+| --- | --- | --- |
+| `{current_version}` | The current version serialized as a string | All hook suites |
+| `{current_<component>}` | The value of a parsed version component, e.g. `{current_major}` | All hook suites |
+| `{new_version}` | The new version serialized as a string | Pre-commit and post-commit hooks |
+| `{new_<component>}` | The value of a parsed new version component, e.g. `{new_major}` | Pre-commit and post-commit hooks |
+
+For example:
+
+    [tool.bumpversion]
+    current_version = "1.2.3"
+    pre_commit_hooks = ["git tag release/{new_major}.{new_minor}"]
+
+During a bump to `1.3.0`, the command becomes:
+
+    git tag release/1.3
+
+Placeholders that do not match a known version key are left unchanged, so existing commands with unrelated braces continue to work.
+
 ### Outputs
 
 The `stdout` and `stderr` streams are echoed to the console if you pass the `-vv` option.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,3 +378,6 @@ check-return-types = false
 skip-checking-raises = true
 quiet = true
 check-class-attributes = false
+
+[tool.bandit.assert_used]
+skips = ['*test_*.py']

--- a/tests/test_hooks/test_format_hooks.py
+++ b/tests/test_hooks/test_format_hooks.py
@@ -1,0 +1,209 @@
+"""Tests for version placeholder substitution in hook commands."""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import pytest
+
+from bumpversion import hooks
+from bumpversion.hooks import (
+    run_post_commit_hooks,
+    run_pre_commit_hooks,
+    run_setup_hooks,
+)
+from tests.conftest import get_config_data
+
+
+class TestFormatHooks:
+    """Tests for the format_hooks helper."""
+
+    @pytest.mark.parametrize(
+        ["hooks_list", "context", "expected"],
+        [
+            pytest.param(
+                ["echo {major}.{minor}.{patch}"],
+                {"major": "1", "minor": "2", "patch": "3"},
+                ["echo 1.2.3"],
+                id="known_placeholders",
+            ),
+            pytest.param(
+                ["echo {major} {unknown} {not_a_key}"],
+                {"major": "1"},
+                ["echo 1 {unknown} {not_a_key}"],
+                id="unknown_placeholders",
+            ),
+            pytest.param(
+                ["git log --pretty=format:'%h %s'", "echo {%not_a_key%}"],
+                {"major": "1"},
+                ["git log --pretty=format:'%h %s'", "echo {%not_a_key%}"],
+                id="unrelated_braces",
+            ),
+            pytest.param(
+                ["echo {major}", "script2"],
+                {},
+                ["echo {major}", "script2"],
+                id="empty_context",
+            ),
+        ],
+    )
+    def test_format_hooks(self, hooks_list: List[str], context: Dict[str, str], expected: List[str]) -> None:
+        """Replace known placeholders and preserve unknown ones."""
+        assert hooks.format_hooks(hooks_list, context) == expected
+
+
+class TestHookContext:
+    """Tests for the hook_context helper."""
+
+    @pytest.mark.parametrize(
+        ["bump_part", "expect_new_version"],
+        [
+            pytest.param(None, False, id="current_only"),
+            pytest.param("minor", True, id="current_and_new"),
+        ],
+    )
+    def test_hook_context(self, bump_part: Optional[str], expect_new_version: bool) -> None:
+        """Build a context with the expected version components."""
+        config, _, current_version = get_config_data({"current_version": "1.2.3"})
+        new_version = current_version.bump(bump_part) if bump_part else None
+        ctx = hooks.hook_context(config, current_version, new_version)
+
+        assert ctx["current_version"] == "1.2.3"
+        assert ctx["current_major"] == "1"
+        assert ctx["current_minor"] == "2"
+        assert ctx["current_patch"] == "3"
+        if expect_new_version:
+            assert ctx["new_version"] == "1.3.0"
+            assert ctx["new_major"] == "1"
+            assert ctx["new_minor"] == "3"
+            assert ctx["new_patch"] == "0"
+        else:
+            assert "new_version" not in ctx
+
+
+SUITE_CASES: List[Tuple[str, Callable, Optional[str], Dict[str, Any], str]] = [
+    pytest.param(
+        "setup",
+        run_setup_hooks,
+        None,
+        {"setup_hooks": ["echo {current_version} {current_major}"]},
+        "echo 1.2.3 1",
+        id="setup",
+    ),
+    pytest.param(
+        "pre_commit",
+        run_pre_commit_hooks,
+        "minor",
+        {"pre_commit_hooks": ["echo {new_version} {new_major}.{new_minor}"]},
+        "echo 1.3.0 1.3",
+        id="pre_commit",
+    ),
+    pytest.param(
+        "post_commit",
+        run_post_commit_hooks,
+        "patch",
+        {"post_commit_hooks": ["git tag release/{new_version}"]},
+        "git tag release/1.2.4",
+        id="post_commit",
+    ),
+]
+
+
+class TestSuiteFormatting:
+    """Tests that each hook suite formats commands before running them."""
+
+    @pytest.fixture
+    def pre_commit_setup(self, mocker):
+        """Return common objects for pre-commit formatting tests."""
+        env = {"var": "value"}
+        mocker.patch("bumpversion.hooks.get_pre_commit_hook_env", return_value=env)
+        config, _, current_version = get_config_data({"current_version": "1.2.3"})
+        new_version = current_version.bump("minor")
+        return config, current_version, new_version, env
+
+    @pytest.mark.parametrize(["suite_name", "suite_func", "bump_part", "overrides", "expected"], SUITE_CASES)
+    def test_suite_formats_version_placeholders(
+        self,
+        mocker,
+        suite_name: str,
+        suite_func: Callable,
+        bump_part: Optional[str],
+        overrides: Dict[str, Any],
+        expected: str,
+    ) -> None:
+        """Each hook suite formats version placeholders before execution."""
+        env = {"var": "value"}
+        mocker.patch(f"bumpversion.hooks.get_{suite_name}_hook_env", return_value=env)
+        mock_run_command = mocker.patch("bumpversion.hooks.run_command")
+        mock_run_command.return_value = mocker.MagicMock(stdout="", stderr="", returncode=0)
+        config, _, current_version = get_config_data({"current_version": "1.2.3", **overrides})
+
+        args = (
+            (config, current_version)
+            if bump_part is None
+            else (config, current_version, current_version.bump(bump_part))
+        )
+        suite_func(*args)
+
+        mock_run_command.assert_called_once_with(expected, env)
+
+    def test_formatting_preserves_unknown_braces(self, mocker, pre_commit_setup) -> None:
+        """Hooks containing braces that are not version placeholders keep them."""
+        config, current_version, new_version, env = pre_commit_setup
+        mock_run_command = mocker.patch("bumpversion.hooks.run_command")
+        mock_run_command.return_value = mocker.MagicMock(stdout="", stderr="", returncode=0)
+        config.pre_commit_hooks = ["git log --pretty=format:'%h'", "echo {not_a_placeholder}"]
+
+        run_pre_commit_hooks(config, current_version, new_version)
+
+        mock_run_command.assert_has_calls(
+            [
+                mocker.call("git log --pretty=format:'%h'", env),
+                mocker.call("echo {not_a_placeholder}", env),
+            ]
+        )
+
+    def test_formatting_before_shell_syntax_check(self, mocker, pre_commit_setup) -> None:
+        """Shell syntax in a formatted hook is still detected and rejected by default."""
+        config, current_version, new_version, _env = pre_commit_setup
+        config.pre_commit_hooks = ["echo {new_version} | cat"]  # noqa: RUF027
+
+        with pytest.raises(hooks.HookError, match="shell syntax"):
+            run_pre_commit_hooks(config, current_version, new_version)
+
+    def test_no_formatting_when_shell_hooks_allowed(self, mocker, pre_commit_setup) -> None:
+        """When allow_shell_hooks is True, the original hook command is passed to run_hooks."""
+        config, current_version, new_version, env = pre_commit_setup
+        config.allow_shell_hooks = True
+        config.pre_commit_hooks = ["echo {new_version}"]  # noqa: RUF027
+        mock_run_hooks = mocker.patch("bumpversion.hooks.run_hooks")
+
+        run_pre_commit_hooks(config, current_version, new_version)
+
+        mock_run_hooks.assert_called_once_with(
+            ["echo {new_version}"],  # noqa: RUF027
+            env,
+            False,
+            allow_shell_hooks=True,
+            context=mocker.ANY,
+        )
+
+
+class TestRunHooksFormatting:
+    """Tests that run_hooks formats commands according to allow_shell_hooks."""
+
+    @pytest.mark.parametrize(
+        ["allow_shell_hooks", "expected_command"],
+        [
+            pytest.param(False, "echo 1.3.0", id="formats_when_safe"),
+            pytest.param(True, "echo {new_version}", id="passes_through_when_shell_allowed"),
+        ],
+    )
+    def test_run_hooks_formatting(self, mocker, allow_shell_hooks: bool, expected_command: str) -> None:
+        """run_hooks formats placeholders only when shell hooks are disabled."""
+        env = {"var": "value"}
+        mock_run_command = mocker.patch("bumpversion.hooks.run_command")
+        mock_run_command.return_value = mocker.MagicMock(stdout="", stderr="", returncode=0)
+        context = {"new_version": "1.3.0"}
+
+        hooks.run_hooks(["echo {new_version}"], env, allow_shell_hooks=allow_shell_hooks, context=context)
+
+        mock_run_command.assert_called_once_with(expected_command, env)


### PR DESCRIPTION
## Added version placeholders in hook commands

### Motivation

I use `changie batch` in a `pre_commit_hook` to prepare a changelog entry as part of the bump. I need to pass the new version to the command, but I don't want to enable `allow_shell_hooks` for security reasons, and I don't want to maintain a separate script file just to read environment variables.

With this change I can write:

```toml
[tool.bumpversion]
current_version = "1.2.3"
pre_commit_hooks = [
    "changie batch --keep {new_version}"
]
```

instead of relying on shell expansion like `$BVHOOK_NEW_VERSION`.

### What changed

- Hook command strings are now searched for version placeholders before execution.
- Placeholders are only substituted when `allow_shell_hooks` is `false` (the default). When shell execution is enabled, commands are passed through unchanged so users can keep using `$BVHOOK_*` variables.
- Unknown placeholders are left untouched, so existing commands with unrelated braces keep working.

### Available placeholders

| Placeholder | Value |
|---|---|
| `{current_version}` | Current serialized version |
| `{new_version}` | New serialized version |
| `{current_<component>}` | Value of a parsed current version component, e.g. `{current_major}` |
| `{new_<component>}` | Value of a parsed new version component, e.g. `{new_major}` |

`{new_version}` and `{new_*}` are not available in setup hooks.

### Notes

- The substitution happens before the shell-syntax check, so a formatted command that ends up containing `|`, `>`, etc. still requires `allow_shell_hooks = true`.
- Docs and tests are included.