### PR TITLE
Fix pre-commit errors and allow test assertions in bandit configuration @minor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,3 +378,6 @@ check-return-types = false
 skip-checking-raises = true
 quiet = true
 check-class-attributes = false
+
+[tool.bandit.assert_used]
+skips = ['*test_*.py']


### PR DESCRIPTION
Allow assertions in tests (bandit missconfiguration) and pre-existing pre-commit errors