### PR TITLE
Add support for tag-only release pushes

### DIFF
--- a/bumpversion/cli_options.py
+++ b/bumpversion/cli_options.py
@@ -192,6 +192,13 @@ tag_option: Callable = click.option(
     help="Create a tag in version control",
 )
 
+push_tag_option: Callable = click.option(
+    "--push-tag/--no-push-tag",
+    default=None,
+    envvar="BUMPVERSION_PUSH_TAG",
+    help="Push the tag to the remote after creation (only works with --tag)",
+)
+
 sign_tags_option: Callable = click.option(
     "--sign-tags/--no-sign-tags",
     default=None,

--- a/bumpversion/commands/bump.py
+++ b/bumpversion/commands/bump.py
@@ -32,6 +32,7 @@ logger = get_indented_logger(__name__)
 @cli_options.dry_run_option
 @cli_options.commit_option
 @cli_options.tag_option
+@cli_options.push_tag_option
 @cli_options.sign_tags_option
 @cli_options.tag_name_option
 @cli_options.tag_message_option
@@ -55,6 +56,7 @@ def bump(
     dry_run: bool,
     commit: Optional[bool],
     tag: Optional[bool],
+    push_tag: Optional[bool],
     sign_tags: Optional[bool],
     tag_name: Optional[str],
     tag_message: Optional[str],
@@ -86,6 +88,7 @@ def bump(
         replace=replace,
         commit=commit,
         tag=tag,
+        push_tag=push_tag,
         sign_tags=sign_tags,
         tag_name=tag_name,
         tag_message=tag_message,

--- a/bumpversion/config/__init__.py
+++ b/bumpversion/config/__init__.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     "ignore_missing_version": False,
     "ignore_missing_files": False,
     "tag": False,
+    "push_tag": False,
     "sign_tags": False,
     "tag_name": "v{new_version}",
     "tag_message": "Bump version: {current_version} → {new_version}",

--- a/bumpversion/config/models.py
+++ b/bumpversion/config/models.py
@@ -94,6 +94,7 @@ class Config(BaseSettings):
     ignore_missing_version: bool
     ignore_missing_files: bool
     tag: bool
+    push_tag: bool
     sign_tags: bool
     tag_name: str
     tag_message: Optional[str]

--- a/bumpversion/scm/git.py
+++ b/bumpversion/scm/git.py
@@ -101,6 +101,8 @@ class Git:
             tag_name = self.config.tag_name.format(**context)
             tag_message = self.config.tag_message.format(**context)
             tag(tag_name, sign=self.config.sign_tags, message=tag_message)
+            if self.config.push_tag:
+                push_remote("origin", tag_name)
 
             for m_tag_name in self.config.moveable_tags:
                 moveable_tag(m_tag_name.format(**context))

--- a/bumpversion/scm/models.py
+++ b/bumpversion/scm/models.py
@@ -19,6 +19,7 @@ class SCMConfig:
     """Configuration for source code management functions."""
 
     tag: bool
+    push_tag: bool
     sign_tags: bool
     tag_name: str
     allow_dirty: bool
@@ -45,6 +46,7 @@ class SCMConfig:
         """Return a SCMConfig from a Config object."""
         return cls(
             tag=config.tag,
+            push_tag=config.push_tag,
             tag_name=config.tag_name,
             sign_tags=config.sign_tags,
             allow_dirty=config.allow_dirty,

--- a/docs/reference/configuration/global.md
+++ b/docs/reference/configuration/global.md
@@ -360,7 +360,30 @@ environment var
 
 If `True`, create a tag after committing the changes. The tag is named using the [`tag_name`](global.md#tag_name) option.
 
-If you are using `git`, don't forget to `git-push` with the `--tags` flag when you are done.
+If you are using `git`, don't forget to `git-push` with the `--tags` flag when you are done, or set [`push_tag`](global.md#push_tag) to `True` to do it automatically.
+
+### push_tag
+
+/// html | div.field-list
+
+required
+: No
+
+default
+: `False` (Don't push the tag)
+
+type
+: boolean
+
+command line option
+: `--push-tag | --no-push-tag`
+
+environment var
+: `BUMPVERSION_PUSH_TAG`
+
+///
+
+If `True`, push the tag to the `origin` remote after it is created, when [`tag`](global.md#tag) is `True`. This is useful for tag-only release processes, where [`commit`](global.md#commit) is `False` and there would otherwise be no other reason to push.
 
 ### tag_message
 
@@ -425,6 +448,7 @@ This string is templated using the [Python Format String Syntax](https://docs.py
     message = "Bump version: {current_version} → {new_version}"
     commit_args = ""
     tag = false
+    push_tag = false
     sign_tags = false
     tag_name = "v{new_version}"
     tag_message = "Bump version: {current_version} → {new_version}"
@@ -446,6 +470,7 @@ This string is templated using the [Python Format String Syntax](https://docs.py
     message = Bump version: {current_version} → {new_version}
     commit_args = 
     tag = False
+    push_tag = False
     sign_tags = False
     tag_name = v{new_version}
     tag_message = Bump version: {current_version} → {new_version}

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -28,6 +28,7 @@ replace = "{new_version}"
 regex = false
 ignore_missing_version = false
 tag = false
+push_tag = false
 sign_tags = false
 tag_name = "v{new_version}"
 tag_message = "Bump version: {current_version} → {new_version}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,7 @@ def scm_config() -> SCMConfig:
     """Dummy SCMConfig fixture."""
     return SCMConfig(
         tag=DEFAULTS["tag"],
+        push_tag=DEFAULTS["push_tag"],
         sign_tags=DEFAULTS["sign_tags"],
         tag_name=DEFAULTS["tag_name"],
         allow_dirty=DEFAULTS["allow_dirty"],

--- a/tests/fixtures/basic_cfg_expected.txt
+++ b/tests/fixtures/basic_cfg_expected.txt
@@ -83,6 +83,7 @@
  'pep621_info': {'version': None},
  'post_commit_hooks': [],
  'pre_commit_hooks': [],
+ 'push_tag': False,
  'regex': False,
  'replace': '{new_version}',
  'scm_info': {'branch_name': None,

--- a/tests/fixtures/basic_cfg_expected.yaml
+++ b/tests/fixtures/basic_cfg_expected.yaml
@@ -115,6 +115,7 @@ post_commit_hooks:
 
 pre_commit_hooks:
 
+push_tag: false
 regex: false
 replace: "{new_version}"
 scm_info:

--- a/tests/fixtures/basic_cfg_expected_full.json
+++ b/tests/fixtures/basic_cfg_expected_full.json
@@ -128,6 +128,7 @@
   },
   "post_commit_hooks": [],
   "pre_commit_hooks": [],
+  "push_tag": false,
   "regex": false,
   "replace": "{new_version}",
   "scm_info": {

--- a/tests/test_scm/test_git.py
+++ b/tests/test_scm/test_git.py
@@ -229,6 +229,38 @@ class TestGit:
             mock_tag.assert_not_called()
             mock_moveable_tag.assert_not_called()
 
+        def test_pushes_tag_when_push_tag_is_true(self, git_instance: Git, mocker):
+            """The method pushes the tag to origin when push_tag is True."""
+            # Arrange
+            files = ["file1.txt"]
+            context = {"new_version": "1.0.0", "new_major": "1", "current_version": "0.1.0"}
+            git_instance.config.tag = True
+            git_instance.config.push_tag = True
+            mocker.patch("bumpversion.scm.git.tag")
+            mock_push_remote = mocker.patch("bumpversion.scm.git.push_remote")
+
+            # Act
+            git_instance.commit_and_tag(files, context, dry_run=False)
+
+            # Assert
+            mock_push_remote.assert_called_once_with("origin", "v1.0.0")
+
+        def test_does_not_push_tag_when_push_tag_is_false(self, git_instance: Git, mocker):
+            """The method does not push the tag when push_tag is False."""
+            # Arrange
+            files = ["file1.txt"]
+            context = {"new_version": "1.0.0", "new_major": "1", "current_version": "0.1.0"}
+            git_instance.config.tag = True
+            git_instance.config.push_tag = False
+            mocker.patch("bumpversion.scm.git.tag")
+            mock_push_remote = mocker.patch("bumpversion.scm.git.push_remote")
+
+            # Act
+            git_instance.commit_and_tag(files, context, dry_run=False)
+
+            # Assert
+            mock_push_remote.assert_not_called()
+
 
 class TestRevisionInfo:
     """Tests for the revision_info function."""


### PR DESCRIPTION
This pull request introduces the following changes:

- Adds documentation for the `push_tag` configuration and its usage in global settings.
- Implements functionality to enable tag-only releases to be pushed directly. @pace-gene
- Adds tests to ensure the accuracy and stability of the new tag-only push feature. @pace-gene

### Checklist

- [x] Tests have been added to cover the changes where needed.
- [x] Documentation has been updated to reflect the changes.
- [x] Code changes are covered by automated tests.
- [x] Any breaking changes have been noted in the description.