### PR TITLE
Fix git branch detection for older git versions and unborn HEAD

### DIFF
--- a/bumpversion/scm/git.py
+++ b/bumpversion/scm/git.py
@@ -209,7 +209,7 @@ def revision_info() -> dict:
     """
     info = dict.fromkeys(["branch_name", "short_branch_name", "repository_root"])
     repo_root_command = ["git", "rev-parse", "--show-toplevel"]
-    current_branch_command = ["git", "branch", "--show-current"]
+    current_branch_command = ["git", "symbolic-ref", "--short", "HEAD"]
 
     try:
         repository_root_result = run_command(repo_root_command)


### PR DESCRIPTION
## Summary
- `git branch --show-current` requires git 2.22+; on older git it raises, the exception is silently swallowed in `revision_info()`, and the function returns early with `repository_root=None`, causing `add_path()` to skip staging every file before `git commit -F`.
- Replace it with `git symbolic-ref --short HEAD`, which works on git 1.x+ and also correctly resolves branch name on an unborn HEAD (repo with no commits yet) — the issue's suggested `git rev-parse --abbrev-ref HEAD` fix breaks that case (prints `HEAD` on a detached/unborn ref) and fails outright on unborn HEAD.

Fixes #426

## Test plan
- [x] `uv run pytest tests/test_scm/test_git.py -k RevisionInfo` passes
- [x] Full suite: `uv run pytest` — 661 passed
- [x] `uv run ruff check` and pre-commit hooks (ruff, mypy, pydoclint, etc.) pass

https://claude.ai/code/session_01NgKrJnSAZmhGvVcwH32w3z